### PR TITLE
[feat][pkg:logger]: optimize zap log format

### DIFF
--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,41 @@
+package logger
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Logger(t *testing.T) {
+	logger1 := GetLogger("test")
+	logger1.Warn("warn for test", String("count", "1"), Reflect("v1", map[string]string{"a": "1"}))
+	logger1.Info("info for test", Uint16("value", 1), Int32("v1", 2),
+		Int64("v2", 2), Any("v3", 3))
+	logger1.Debug("debug for test", Uint32("value", 2))
+	logger1.Error("error for test", Error(fmt.Errorf("error")))
+
+	logger2 := New()
+	assert.NotNil(t, logger2)
+}
+
+func Test_Logger_Stack(t *testing.T) {
+	panicFunc := func() {
+		defer func() {
+			if r := recover(); r != nil {
+				GetLogger("test-panic").log.Panic("panic stack", Stack())
+			}
+		}()
+		panic("test-panic")
+	}
+	assert.Panics(t, panicFunc)
+}
+
+func Test_IsTerminal(t *testing.T) {
+	assert.False(t, IsTerminal(os.Stdout))
+
+	w := bytes.NewBuffer(nil)
+	assert.False(t, IsTerminal(w))
+}


### PR DESCRIPTION
> new format

- [2019-08-16 - 17:46:30]	[info]	[standalone]: etcd server is ready
- [2019-08-16 - 17:46:30]	[info]	[state]: new etcd client successfully	{"endpoints": ["http://localhost:2379"]}
- [2019-08-16 - 17:46:30]	[info]	[state]: new etcd client successfully	{"endpoints": ["http://localhost:2379"]}
- [2019-08-16 - 17:46:30]	[info]	[storage/runtime]: start storage state repository successfully
- [2019-08-16 - 17:46:30]	[info]	[storage/task/executor]: task executor started

> old format

- 2019-08-16T17:49:40.339+0800	info	[standalone]:etcd server is ready
- 2019-08-16T17:49:40.341+0800	info	[state]:new etcd client successfully	{"endpoints": ["http://localhost:2379"]}
- 2019-08-16T17:49:40.355+0800	info	[state]:new etcd client successfully	{"endpoints": ["http://localhost:2379"]}
- 2019-08-16T17:49:40.355+0800	info	[storage/runtime]:start storage state repository successfully