### PR TITLE
[feat:#170][tsdb]: add series reader to support series.Filter

### DIFF
--- a/pkg/stream/binary.go
+++ b/pkg/stream/binary.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
 // Binary is stream for writing data into memory buffer
@@ -138,12 +139,20 @@ func (b *Binary) ReadUvarint64() uint64 {
 // ReadUint32 read 4 bytes from buf as uint32
 func (b *Binary) ReadUint32() uint32 {
 	buf := b.ReadBytes(4)
+	if len(buf) != 4 {
+		b.err = fmt.Errorf("EOF occurs when ReadUint32")
+		return 0
+	}
 	return binary.LittleEndian.Uint32(buf)
 }
 
 // ReadUint64 read 8 bytes from buf as uint64
 func (b *Binary) ReadUint64() uint64 {
 	buf := b.ReadBytes(8)
+	if len(buf) != 8 {
+		b.err = fmt.Errorf("EOF occurs when ReadUint64")
+		return 0
+	}
 	return binary.LittleEndian.Uint64(buf)
 }
 
@@ -163,6 +172,7 @@ func (b *Binary) ReadByte() byte {
 	if len(data) == 1 {
 		return data[0]
 	}
+	b.err = fmt.Errorf("read byte failed")
 	return byte(0)
 }
 

--- a/pkg/stream/binary_test.go
+++ b/pkg/stream/binary_test.go
@@ -88,10 +88,18 @@ func Test_Read(t *testing.T) {
 	assert.Equal(t, byte(7), reader.ReadByte())
 	assert.Equal(t, byte(0), reader.ReadByte())
 	assert.True(t, reader.Empty())
-	assert.Nil(t, reader.Error())
+	assert.NotNil(t, reader.Error())
 
 	// test error read uvariant64
 	reader = BinaryReader(nil)
 	reader.ReadUvarint64()
+	assert.NotNil(t, reader.Error())
+
+	// test error read uint32, uint64
+	reader = BinaryReader(nil)
+	reader.ReadUint32()
+	assert.NotNil(t, reader.Error())
+	reader = BinaryReader(nil)
+	reader.ReadUint64()
 	assert.NotNil(t, reader.Error())
 }

--- a/query/series_search_test.go
+++ b/query/series_search_test.go
@@ -17,7 +17,7 @@ func TestSampleCondition(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockFilter := series.NewMockFilter(ctrl)
-	s := mockSeriesIDSet(int64(1), roaring.BitmapOf(1, 2, 3, 4))
+	s := mockSeriesIDSet(uint32(1), roaring.BitmapOf(1, 2, 3, 4))
 
 	query, _ := sql.Parse("select f from cpu")
 	search := newSeriesSearch(1, mockFilter, query)
@@ -75,20 +75,20 @@ func TestNotCondition(t *testing.T) {
 	query, _ := sql.Parse("select f from cpu where ip!='1.1.1.1'")
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "ip", Value: "1.1.1.1"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(3, 4)), nil)
 
 	mockFilter.EXPECT().
 		GetSeriesIDsForTag(uint32(1), "ip", query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
 	search := newSeriesSearch(1, mockFilter, query)
 	resultSet, _ := search.Search()
-	assert.Equal(t, *mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2)), *resultSet)
+	assert.Equal(t, *mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2)), *resultSet)
 
 	// error
 	query, _ = sql.Parse("select f from cpu where ip!='1.1.1.1'")
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "ip", Value: "1.1.1.1"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(3, 4)), nil)
 
 	mockFilter.EXPECT().
 		GetSeriesIDsForTag(uint32(1), "ip", query.TimeRange).
@@ -109,13 +109,13 @@ func TestBinaryCondition(t *testing.T) {
 		"where ip='1.1.1.1' and path='/data' and time>'20190410 00:00:00' and time<'20190410 10:00:00'")
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "ip", Value: "1.1.1.1"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "path", Value: "/data"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(3, 5)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(3, 5)), nil)
 	search := newSeriesSearch(1, mockFilter, query)
 	resultSet, _ := search.Search()
-	assert.Equal(t, *mockSeriesIDSet(int64(11), roaring.BitmapOf(3)), *resultSet)
+	assert.Equal(t, *mockSeriesIDSet(uint32(11), roaring.BitmapOf(3)), *resultSet)
 
 	// or
 	mockFilter2 := series.NewMockFilter(ctrl)
@@ -123,13 +123,13 @@ func TestBinaryCondition(t *testing.T) {
 		"where ip='1.1.1.1' or path='/data' and time>'20190410 00:00:00' and time<'20190410 10:00:00'")
 	mockFilter2.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "ip", Value: "1.1.1.1"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
 	mockFilter2.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "path", Value: "/data"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(3, 5)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(3, 5)), nil)
 	search = newSeriesSearch(1, mockFilter2, query)
 	resultSet, _ = search.Search()
-	assert.Equal(t, *mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4, 5)), *resultSet)
+	assert.Equal(t, *mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4, 5)), *resultSet)
 
 	// error
 	mockFilter3 := series.NewMockFilter(ctrl)
@@ -146,7 +146,7 @@ func TestBinaryCondition(t *testing.T) {
 		"where ip='1.1.1.1' or path='/data' and time>'20190410 00:00:00' and time<'20190410 10:00:00'")
 	mockFilter4.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "ip", Value: "1.1.1.1"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4)), nil)
 	mockFilter4.EXPECT().
 		FindSeriesIDsByExpr(uint32(1), &stmt.EqualsExpr{Key: "path", Value: "/data"}, query.TimeRange).
 		Return(nil, errors.New("right error"))
@@ -165,35 +165,35 @@ func TestComplexCondition(t *testing.T) {
 		" where (ip not in ('1.1.1.1','2.2.2.2') and region='sh') and (path='/data' or path='/home')")
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.InExpr{Key: "ip", Values: []string{"1.1.1.1", "2.2.2.2"}}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 4)), nil)
 	mockFilter.EXPECT().
 		GetSeriesIDsForTag(uint32(10), "ip", query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4, 6, 7, 8)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4, 6, 7, 8)), nil)
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.EqualsExpr{Key: "region", Value: "sh"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(2, 3, 4, 7)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(2, 3, 4, 7)), nil)
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.EqualsExpr{Key: "path", Value: "/data"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(3, 5)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(3, 5)), nil)
 	mockFilter.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.EqualsExpr{Key: "path", Value: "/home"}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1)), nil)
 	search := newSeriesSearch(10, mockFilter, query)
 	resultSet, _ := search.Search()
 	// ip not in ('1.1.1.1','2.2.2.2') => 3,6,7,8
 	// ip not in ('1.1.1.1','2.2.2.2') and region='sh' => 3,7
 	// path='/data' or path='/home' => 1,3,5
 	// final => 3
-	assert.Equal(t, *mockSeriesIDSet(int64(11), roaring.BitmapOf(3)), *resultSet)
+	assert.Equal(t, *mockSeriesIDSet(uint32(11), roaring.BitmapOf(3)), *resultSet)
 
 	// error
 	mockFilter1 := series.NewMockFilter(ctrl)
 	mockFilter1.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.InExpr{Key: "ip", Values: []string{"1.1.1.1", "2.2.2.2"}}, query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 4)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 4)), nil)
 	mockFilter1.EXPECT().
 		GetSeriesIDsForTag(uint32(10), "ip", query.TimeRange).
-		Return(mockSeriesIDSet(int64(11), roaring.BitmapOf(1, 2, 3, 4, 6, 7, 8)), nil)
+		Return(mockSeriesIDSet(uint32(11), roaring.BitmapOf(1, 2, 3, 4, 6, 7, 8)), nil)
 	mockFilter1.EXPECT().
 		FindSeriesIDsByExpr(uint32(10), &stmt.EqualsExpr{Key: "region", Value: "sh"}, query.TimeRange).
 		Return(nil, errors.New("complex error"))
@@ -203,7 +203,7 @@ func TestComplexCondition(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func mockSeriesIDSet(version int64, ids *roaring.Bitmap) *series.MultiVerSeriesIDSet {
+func mockSeriesIDSet(version uint32, ids *roaring.Bitmap) *series.MultiVerSeriesIDSet {
 	s := series.NewMultiVerSeriesIDSet()
 	s.Add(version, ids)
 	return s

--- a/query/storage_plan_test.go
+++ b/query/storage_plan_test.go
@@ -31,10 +31,10 @@ func TestStoragePlan_Metric(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	metadataIndex.EXPECT().GetMetricID(gomock.Any()).Return(uint32(0), series.ErrMetaDataNotExist)
+	metadataIndex.EXPECT().GetMetricID(gomock.Any()).Return(uint32(0), series.ErrNotFound)
 	plan = newStorageExecutePlan(metadataIndex, query)
 	err = plan.Plan()
-	assert.Equal(t, series.ErrMetaDataNotExist, err)
+	assert.Equal(t, series.ErrNotFound, err)
 }
 
 func TestStoragePlan_SelectList(t *testing.T) {
@@ -55,7 +55,7 @@ func TestStoragePlan_SelectList(t *testing.T) {
 		Return(uint16(14), field.HistogramField, nil).AnyTimes()
 
 	metadataIndex.EXPECT().GetFieldID(gomock.Any(), "no_f").
-		Return(uint16(99), field.HistogramField, series.ErrMetaDataNotExist).AnyTimes()
+		Return(uint16(99), field.HistogramField, series.ErrNotFound).AnyTimes()
 
 	// error
 	query := &stmt.Query{MetricName: "cpu"}
@@ -65,7 +65,7 @@ func TestStoragePlan_SelectList(t *testing.T) {
 	query, _ = sql.Parse("select no_f from cpu")
 	plan = newStorageExecutePlan(metadataIndex, query)
 	err = plan.Plan()
-	assert.Equal(t, series.ErrMetaDataNotExist, err)
+	assert.Equal(t, series.ErrNotFound, err)
 
 	// normal
 	query, _ = sql.Parse("select f from cpu")

--- a/tsdb/indexdb/database_test.go
+++ b/tsdb/indexdb/database_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lindb/lindb/sql/stmt"
+
 	"github.com/lindb/lindb/kv"
 	"github.com/lindb/lindb/kv/table"
 	"github.com/lindb/lindb/pkg/field"
@@ -181,15 +183,16 @@ func Test_IndexDatabase(t *testing.T) {
 	assert.Nil(t, tagValues)
 	assert.Nil(t, err)
 
-	mockSeriesReader.EXPECT().FindSeriesIDsByExpr(gomock.Any(), gomock.Any(), gomock.Any()).
+	db.youngTagKeyIDs = map[uint32][]tagKeyAndID{1: {{tagKey: "host", tagKeyID: 2}, {tagKey: "zone", tagKeyID: 3}}}
+	mockSeriesReader.EXPECT().FindSeriesIDsByExprForTagID(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil)
-	set, err := db.FindSeriesIDsByExpr(1, nil, timeutil.TimeRange{})
+	set, err := db.FindSeriesIDsByExpr(1, &stmt.EqualsExpr{Key: "host", Value: "dev"}, timeutil.TimeRange{})
 	assert.Nil(t, set)
 	assert.Nil(t, err)
 
-	mockSeriesReader.EXPECT().GetSeriesIDsForTag(gomock.Any(), gomock.Any(), gomock.Any()).
+	mockSeriesReader.EXPECT().GetSeriesIDsForTagID(gomock.Any(), gomock.Any()).
 		Return(nil, nil)
-	set, err = db.GetSeriesIDsForTag(1, "", timeutil.TimeRange{})
+	set, err = db.GetSeriesIDsForTag(1, "zone", timeutil.TimeRange{})
 	assert.Nil(t, set)
 	assert.Nil(t, err)
 }

--- a/tsdb/indexdb/interface.go
+++ b/tsdb/indexdb/interface.go
@@ -20,10 +20,12 @@ type IDGenerator interface {
 
 // IDGetter represents the query ability for metric level, such as metric id, field meta etc.
 type IDGetter interface {
-	// GetMetricID returns metric ID(uint32), if not exist return ErrNotExist error
+	// GetMetricID returns metric ID(uint32), if not exist return ErrNotFound error
 	GetMetricID(metricName string) (uint32, error)
+	// GetTagID returns tag ID(uint32), return ErrNotFound if not exist
+	GetTagID(metricID uint32, tagKey string) (tagID uint32, err error)
 	// GetFieldID returns field id and type by given metricID and field name,
-	// if not exist return ErrNotExist error
+	// if not exist return ErrNotFound error
 	GetFieldID(metricID uint32, fieldName string) (fieldID uint16, fieldType field.Type, err error)
 }
 
@@ -33,7 +35,7 @@ type IDGetter interface {
 type IndexDatabase interface {
 	IDGenerator
 	IDGetter
-	series.MetadataGetter
+	series.MetaGetter
 	series.Filter
 	// FlushNameIDsTo flushes metricName and metricID to flusher
 	FlushNameIDsTo(flusher kv.Flusher) error

--- a/tsdb/indextbl/rank_select.go
+++ b/tsdb/indextbl/rank_select.go
@@ -117,7 +117,6 @@ func (rs *rankSelect) LastChild(nodeNumber uint64) (childNodeNumber uint64, ok b
 	pos := rs.Position(nodeNumber)
 	childPos := rs.Select0(rs.Rank1(pos)+1) - 1
 	return rs.NodeNumber(childPos), rs.Bit(childPos)
-
 }
 
 func (rs *rankSelect) ChildrenNum(nodeNumber uint64) uint64 {

--- a/tsdb/indextbl/series_flusher_test.go
+++ b/tsdb/indextbl/series_flusher_test.go
@@ -11,23 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func prepareTestKVSets() []VersionedTagKVEntrySet {
-	bitmap1 := roaring.New()
-	bitmap1.AddRange(1, 100)
-	bitmap2 := roaring.New()
-	bitmap2.AddRange(300, 400)
-
-	return []VersionedTagKVEntrySet{
-		{Version: 1, EntrySet: map[string]*roaring.Bitmap{
-			"nj": bitmap1,
-			"bj": bitmap2}},
-		{Version: 2, EntrySet: map[string]*roaring.Bitmap{
-			"nt": roaring.New(),
-			"sz": roaring.New()}},
-	}
-}
-
-func Test_SeriesIndexFlusher(t *testing.T) {
+func Test_SeriesIndexFlusher_Commit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -39,10 +23,9 @@ func Test_SeriesIndexFlusher(t *testing.T) {
 	mockFlusher.EXPECT().Commit().Return(fmt.Errorf("commit error"))
 	assert.NotNil(t, indexFlusher.Commit())
 
-	// flush tag key, zone=nj, zone=bj
-	testData := prepareTestKVSets()
+	// mock commit ok
 	mockFlusher.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	err := indexFlusher.FlushTagKey(333, testData)
+	err := indexFlusher.FlushTagKey(333)
 	assert.Nil(t, err)
 }
 
@@ -53,25 +36,51 @@ func Test_SeriesIndexFlusher_RS_error(t *testing.T) {
 	mockFlusher := kv.NewMockFlusher(ctrl)
 	indexFlusher := NewSeriesIndexFlusher(mockFlusher).(*seriesIndexFlusher)
 
-	testData := prepareTestKVSets()
 	mockFlusher.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	// mock trie tree
-	mockTrie := NewMocktrieTreeINTF(ctrl)
-	mockTrie.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
+	mockTrie := NewMocktrieTreeBuilder(ctrl)
+	mockTrie.EXPECT().Add(gomock.Any(), gomock.Any()).Return().AnyTimes()
 	mockTrie.EXPECT().Reset().Return().AnyTimes()
 	// mock rank select
 	mockRS := NewMockRSINTF(ctrl)
 	// mock binary return
-	mockBin := &seriesBinData{LOUDS: mockRS, isPrefixKey: mockRS, labels: nil, values: nil}
+	mockBin := &trieTreeData{
+		trieTreeBlock: trieTreeBlock{LOUDS: mockRS, isPrefixKey: mockRS, labels: nil},
+		values:        nil}
+
 	mockTrie.EXPECT().MarshalBinary().Return(mockBin).AnyTimes()
 	// replace trie with mock
 	indexFlusher.trie = mockTrie
 
 	// mock isPrefixKey error
 	mockRS.EXPECT().MarshalBinary().Return(nil, fmt.Errorf("error1"))
-	assert.NotNil(t, indexFlusher.FlushTagKey(11, testData))
+	assert.NotNil(t, indexFlusher.FlushTagKey(11))
 	// mock LOUDS error
 	mockRS.EXPECT().MarshalBinary().Return([]byte("12345"), nil)
 	mockRS.EXPECT().MarshalBinary().Return(nil, fmt.Errorf("error2"))
-	assert.NotNil(t, indexFlusher.FlushTagKey(11, testData))
+	assert.NotNil(t, indexFlusher.FlushTagKey(11))
+}
+
+func Test_SeriesIndexFlusher_OK(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFlusher := kv.NewMockFlusher(ctrl)
+	mockFlusher.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil)
+	indexFlusher := NewSeriesIndexFlusher(mockFlusher)
+
+	// flush versions of tagValue1
+	indexFlusher.FlushVersion(1, 3, 5, roaring.New())
+	indexFlusher.FlushVersion(2, 4, 6, roaring.New())
+	indexFlusher.FlushVersion(3, 1, 2, roaring.New())
+	// flush tagValue1
+	indexFlusher.FlushTagValue("1")
+	// flush versions of tagValue2
+	indexFlusher.FlushVersion(1, 12, 15, roaring.New())
+	indexFlusher.FlushVersion(2, 15, 20, roaring.New())
+	indexFlusher.FlushVersion(3, 22, 24, roaring.New())
+	// flush tagValue2
+	indexFlusher.FlushTagValue("2")
+	// flush tagKey
+	assert.Nil(t, indexFlusher.FlushTagKey(0))
 }

--- a/tsdb/indextbl/series_reader.go
+++ b/tsdb/indextbl/series_reader.go
@@ -1,20 +1,35 @@
 package indextbl
 
 import (
+	"fmt"
+	"sort"
+
+	"github.com/RoaringBitmap/roaring"
+
 	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/pkg/bufioutil"
+	"github.com/lindb/lindb/pkg/logger"
+	"github.com/lindb/lindb/pkg/stream"
 	"github.com/lindb/lindb/pkg/timeutil"
 	"github.com/lindb/lindb/sql/stmt"
 	"github.com/lindb/lindb/tsdb/series"
 )
 
-// todo: @codingcrush, implementation
-
 //go:generate mockgen -source ./series_reader.go -destination=./series_reader_mock.go -package indextbl
 
-// SeriesIndexReader reads tag k/v info from the kv table
+const (
+	timeRangeSize = 4 + // uint32, start-time
+		4 // uint32, end-time
+)
+
+// SeriesIndexReader reads versioned seriesID bitmap from series-index-table
 type SeriesIndexReader interface {
-	series.Filter
-	series.MetadataGetter
+	// GetSeriesIDsForTagID get series ids for spec metric's keyID
+	GetSeriesIDsForTagID(tagID uint32, timeRange timeutil.TimeRange) (*series.MultiVerSeriesIDSet, error)
+	// FindSeriesIDsByExprForTagID finds series ids by tag filter expr and tagID
+	FindSeriesIDsByExprForTagID(tagID uint32, expr stmt.TagFilter,
+		timeRange timeutil.TimeRange) (*series.MultiVerSeriesIDSet, error)
+	series.MetaGetter
 }
 
 // seriesIndexReader implements SeriesIndexReader
@@ -28,19 +43,266 @@ func NewSeriesIndexReader(snapshot kv.Snapshot) SeriesIndexReader {
 }
 
 // GetTagValues returns tag values by tag keys and spec version for metric level
-func (r *seriesIndexReader) GetTagValues(metricID uint32, tagKeys []string, version int64) (
+func (r *seriesIndexReader) GetTagValues(metricID uint32, tagKeys []string, version uint32) (
 	tagValues [][]string, err error) {
+	// todo: @codingcrush, #92 forward index implementation
 	return nil, nil
 }
 
-// FindSeriesIDsByExpr finds series ids by tag filter expr for metric id
-func (r *seriesIndexReader) FindSeriesIDsByExpr(metricID uint32, expr stmt.TagFilter,
+// FindSeriesIDsByExprForTagID finds series ids by tag filter expr for tagId
+func (r *seriesIndexReader) FindSeriesIDsByExprForTagID(tagID uint32, expr stmt.TagFilter,
 	timeRange timeutil.TimeRange) (*series.MultiVerSeriesIDSet, error) {
-	return nil, nil
+	entrySetBlocks := r.filterEntrySetBlocks(tagID, timeRange)
+	if len(entrySetBlocks) == 0 {
+		return nil, series.ErrNotFound
+	}
+	unionIDSet := series.NewMultiVerSeriesIDSet()
+	for _, entrySetBlock := range entrySetBlocks {
+		var offsets []int
+		q, err := r.entrySetBlockToTreeQuerier(entrySetBlock)
+		if err != nil {
+			moduleLogger.Error("failed reading trie-tree block", logger.Error(err))
+			continue
+		}
+		switch expression := expr.(type) {
+		case *stmt.EqualsExpr:
+			offsets = append(offsets, q.FindOffsetsByEqual(expression.Value)...)
+		case *stmt.InExpr:
+			offsets = append(offsets, q.FindOffsetsByIn(expression.Values)...)
+		case *stmt.LikeExpr:
+			offsets = append(offsets, q.FindOffsetsByLike(expression.Value)...)
+		case *stmt.RegexExpr:
+			offsets = append(offsets, q.FindOffsetsByRegex(expression.Regexp)...)
+		default:
+			return nil, series.ErrNotFound
+		}
+		if len(offsets) == 0 {
+			continue
+		}
+		idSet, err := r.entrySetBlockToIDSet(entrySetBlock, timeRange, offsets)
+		if err != nil {
+			return nil, err
+		}
+		if idSet == nil {
+			continue
+		}
+		unionIDSet.Or(idSet)
+	}
+	if unionIDSet.IsEmpty() {
+		return nil, series.ErrNotFound
+	}
+	return unionIDSet, nil
 }
 
-// GetSeriesIDsForTag get series ids for spec metric's tag key
-func (r *seriesIndexReader) GetSeriesIDsForTag(metricID uint32, tagKey string,
+// GetSeriesIDsForTagID get series ids for spec metric's tag keyID
+func (r *seriesIndexReader) GetSeriesIDsForTagID(tagID uint32,
 	timeRange timeutil.TimeRange) (*series.MultiVerSeriesIDSet, error) {
-	return nil, nil
+	entrySetBlocks := r.filterEntrySetBlocks(tagID, timeRange)
+	if len(entrySetBlocks) == 0 {
+		return nil, series.ErrNotFound
+	}
+	unionIDSet := series.NewMultiVerSeriesIDSet()
+	for _, entrySetBlock := range entrySetBlocks {
+		idSet, err := r.entrySetBlockToIDSet(entrySetBlock, timeRange, nil)
+		if err != nil {
+			return nil, err
+		}
+		if idSet == nil {
+			continue
+		}
+		unionIDSet.Or(idSet)
+	}
+	return unionIDSet, nil
+}
+
+// filterEntrySetBlocks filters the entry-set block which matches the time-range in the series-index-table
+func (r *seriesIndexReader) filterEntrySetBlocks(tagID uint32, timeRange timeutil.TimeRange) (entrySetBlocks [][]byte) {
+	for _, reader := range r.snapshot.Readers() {
+		block := reader.Get(tagID)
+		if len(block) <= timeRangeSize {
+			continue
+		}
+		// read time-range of the total entry-set
+		sr := stream.BinaryReader(block)
+		startTime := sr.ReadUint32()
+		endTime := sr.ReadUint32()
+		blockTimeRange := timeutil.TimeRange{
+			Start: int64(startTime) * 1000,
+			End:   int64(endTime) * 1000}
+		if !timeRange.Overlap(&blockTimeRange) {
+			continue
+		}
+		entrySetBlocks = append(entrySetBlocks, block)
+	}
+	return
+}
+
+// entrySetBlockToTreeQuerier converts the binary block to a tire tree block querier
+func (r *seriesIndexReader) entrySetBlockToTreeQuerier(block []byte) (trieTreeQuerier, error) {
+	var tree trieTreeBlock
+	sr := stream.BinaryReader(block)
+	// read time-range
+	_ = sr.ReadBytes(timeRangeSize)
+	////////////////////////////////
+	// Block: LOUDS Trie-Tree
+	////////////////////////////////
+	// read trie-tree length
+	expectedTrieTreeLen := sr.ReadUvarint64()
+	// read label length
+	labelsLen := sr.ReadUvarint64()
+	// read labels block
+	tree.labels = sr.ReadBytes(int(labelsLen))
+	// read isPrefix length
+	isPrefixKeyLen := sr.ReadUvarint64()
+	// read isPrefixKey bitmap
+	isPrefixBlock := sr.ReadBytes(int(isPrefixKeyLen))
+	// read LOUDS length
+	loudsLen := sr.ReadUvarint64()
+	// read LOUDS block
+	LOUDSBlock := sr.ReadBytes(int(loudsLen))
+	// validation of stream error
+	if sr.Error() != nil {
+		return nil, sr.Error()
+	}
+	// validation of length
+	realTrieTreeBlockLen := bufioutil.GetUVariantLength(labelsLen) +
+		len(tree.labels) +
+		bufioutil.GetUVariantLength(isPrefixKeyLen) +
+		len(isPrefixBlock) +
+		bufioutil.GetUVariantLength(loudsLen) +
+		len(LOUDSBlock)
+	if realTrieTreeBlockLen != int(expectedTrieTreeLen) {
+		return nil, fmt.Errorf("failed validation of trie-tree")
+	}
+	// unmarshal LOUDS block to rank-select
+	tree.LOUDS = NewRankSelect()
+	if err := tree.LOUDS.UnmarshalBinary(LOUDSBlock); err != nil {
+		return nil, err
+	}
+	// unmarshal isPrefixKey block to rank-select
+	tree.isPrefixKey = NewRankSelect()
+	if err := tree.isPrefixKey.UnmarshalBinary(isPrefixBlock); err != nil {
+		return nil, err
+	}
+	return &tree, nil
+}
+
+// entrySetBlockToIDSet parses the entry-set block, then return the multi-versions seriesID bitmap
+func (r *seriesIndexReader) entrySetBlockToIDSet(block []byte, timeRange timeutil.TimeRange,
+	offsets []int) (*series.MultiVerSeriesIDSet, error) {
+
+	// read trie-tree length
+	sr := stream.BinaryReader(block)
+	_ = sr.ReadBytes(timeRangeSize)
+	trieTreeLen := sr.ReadUvarint64()
+	cursorPos := timeRangeSize + // time range
+		bufioutil.GetUVariantLength(trieTreeLen) + int(trieTreeLen) // tree block
+	if len(block) <= cursorPos {
+		return nil, fmt.Errorf("entrySet block length:%d validation failure", cursorPos)
+	}
+	// move to the end of trie-tree
+	sr = stream.BinaryReader(block[cursorPos:])
+	////////////////////////////////
+	// Block: TagValue Info
+	////////////////////////////////
+	// read tag-value count
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+	tagValueCount := sr.ReadUvarint64()
+	if tagValueCount == 0 {
+		return nil, fmt.Errorf("tagValueCount equals to 0")
+	}
+	// move to tagValueCount
+	cursorPos += bufioutil.GetUVariantLength(tagValueCount)
+	var (
+		// offsets to the end of tagValueInfo block
+		tagValueDataBlockOffsets []int
+		offsetCounter            = 0
+	)
+	for i := 0; i < int(tagValueCount); i++ {
+		dataLen := sr.ReadUvarint64()
+		if sr.Error() != nil {
+			return nil, sr.Error()
+		}
+		// offsets is nil means traversing all blocks of tagValueData
+		// offsets contains i mean that is specified offset will be searched
+		if len(offsets) == 0 || intSliceContains(offsets, i) {
+			tagValueDataBlockOffsets = append(tagValueDataBlockOffsets, offsetCounter)
+		}
+		offsetCounter += int(dataLen)
+		cursorPos += bufioutil.GetUVariantLength(dataLen)
+	}
+	////////////////////////////////
+	// Block: Versioned TagValue Data
+	////////////////////////////////
+	if len(tagValueDataBlockOffsets) == 0 {
+		return nil, series.ErrNotFound
+	}
+	idSet := series.NewMultiVerSeriesIDSet()
+	for _, offset := range tagValueDataBlockOffsets {
+		subIDSet, err := r.readTagValueDataBlock(block, offset+cursorPos, timeRange)
+		if err != nil {
+			return nil, err
+		}
+		if subIDSet == nil {
+			continue
+		}
+		idSet.Or(subIDSet)
+	}
+	return idSet, nil
+}
+
+// readTagValueDataBlock parses the tagValueDataBlock, and return the the multi-versions seriesID bitmap
+func (r *seriesIndexReader) readTagValueDataBlock(block []byte, pos int,
+	timeRange timeutil.TimeRange) (*series.MultiVerSeriesIDSet, error) {
+	if len(block) <= pos {
+		return nil, fmt.Errorf("failed validation of tagValueData's length")
+	}
+	sr := stream.BinaryReader(block[pos:])
+	// read VersionCount
+	versionCount := sr.ReadUvarint64()
+	if versionCount == 0 {
+		return nil, fmt.Errorf("versionCount equals to 0")
+	}
+	var (
+		idSet       *series.MultiVerSeriesIDSet
+		readCounter = 0
+	)
+	for !sr.Empty() && readCounter < int(versionCount) {
+		// read version
+		version := sr.ReadUint32()
+		// read start-time delta
+		startTime := sr.ReadVarint64()*1000 + int64(version)*1000 // startTime in milliseconds
+		// read end-time delta
+		endTime := sr.ReadVarint64()*1000 + int64(version)*1000 // endTime in milliseconds
+		// read bitmap length
+		bitMapLen := int(sr.ReadUvarint64())
+		// read bitmap
+		bitMapBlock := sr.ReadBytes(bitMapLen)
+		if sr.Error() != nil {
+			return nil, sr.Error()
+		}
+		// finished read a full VersionedTagValue block
+		// check time range
+		if !timeRange.Overlap(&timeutil.TimeRange{Start: startTime, End: endTime}) {
+			readCounter++
+			continue
+		}
+		// unmarshal bitmap
+		bitMap := roaring.New()
+		if err := bitMap.UnmarshalBinary(bitMapBlock); err != nil {
+			return nil, err
+		}
+		if idSet == nil {
+			idSet = series.NewMultiVerSeriesIDSet()
+		}
+		idSet.Add(version, bitMap)
+		readCounter++
+	}
+	return idSet, nil
+}
+
+// intSliceContains detects if item is in the slice
+func intSliceContains(slice []int, item int) bool {
+	idx := sort.Search(len(slice), func(i int) bool { return slice[i] >= item })
+	return idx < len(slice) && slice[idx] == item
 }

--- a/tsdb/indextbl/series_reader_test.go
+++ b/tsdb/indextbl/series_reader_test.go
@@ -3,27 +3,341 @@ package indextbl
 import (
 	"testing"
 
+	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/kv/table"
 	"github.com/lindb/lindb/pkg/timeutil"
+	"github.com/lindb/lindb/sql/stmt"
 
+	"github.com/RoaringBitmap/roaring"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_SeriesIndexReader(t *testing.T) {
-	reader := NewSeriesIndexReader(nil)
-	assert.NotNil(t, reader)
+func buildSeriesIndexBlock(ctrl *gomock.Controller) (zoneBlock []byte, ipBlock []byte, hostBlock []byte) {
+	kvFlusher := kv.NewMockFlusher(ctrl)
+	kvFlusher.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	seriesFlusher := NewSeriesIndexFlusher(kvFlusher)
+	seriesFlusherImpl := seriesFlusher.(*seriesIndexFlusher)
+	// disable auto reset to pick the entrySetBuffer
+	seriesFlusherImpl.resetDisabled = true
+	/////////////////////////
+	// seriesID mapping relation
+	/////////////////////////
+	ipMapping := map[uint32]string{
+		1: "192.168.1.1",
+		2: "192.168.1.2",
+		3: "192.168.1.3",
+		4: "192.168.2.4",
+		5: "192.168.2.5",
+		6: "192.168.2.6",
+		7: "192.168.3.7",
+		8: "192.168.3.8",
+		9: "192.168.3.9"}
+	zoneMapping := map[string][]uint32{
+		"nj": {1, 2, 3},
+		"sh": {4, 5, 6},
+		"bj": {7, 8, 9}}
+	hostMapping := map[uint32]string{
+		1: "eleme-dev-nj-1",
+		2: "eleme-dev-nj-2",
+		3: "eleme-dev-nj-3",
+		4: "eleme-dev-sh-4",
+		5: "eleme-dev-sh-5",
+		6: "eleme-dev-sh-6",
+		7: "eleme-dev-bj-7",
+		8: "eleme-dev-bj-8",
+		9: "eleme-dev-bj-9"}
+	/////////////////////////
+	// flush zone tag, tagID: 20
+	/////////////////////////
+	for zone, ids := range zoneMapping {
+		for version := uint32(1500000000); version < 1800000000; version += 100000000 {
+			bitmap := roaring.New()
+			bitmap.AddMany(ids)
+			seriesFlusher.FlushVersion(version, version+10000, version+20000, bitmap)
+		}
+		seriesFlusher.FlushTagValue(zone)
+	}
+	// pick the zoneBlock buffer
+	seriesFlusher.FlushTagKey(20)
+	zoneBlock = append(zoneBlock, seriesFlusherImpl.entrySetBuffer.Bytes()...)
+	seriesFlusherImpl.reset()
 
-	// GetTagValues
-	tagValues, err := reader.GetTagValues(1, nil, 0)
+	/////////////////////////
+	// flush ip tag, tagID: 21
+	/////////////////////////
+	for seriesID, ip := range ipMapping {
+		for version := uint32(1500000000); version < 1800000000; version += 100000000 {
+			bitmap := roaring.New()
+			bitmap.Add(seriesID)
+			seriesFlusher.FlushVersion(version, version+10000, version+20000, bitmap)
+		}
+		seriesFlusher.FlushTagValue(ip)
+	}
+	// pick the ipBlock buffer
+	seriesFlusher.FlushTagKey(21)
+	ipBlock = append(ipBlock, seriesFlusherImpl.entrySetBuffer.Bytes()...)
+	seriesFlusherImpl.reset()
+
+	/////////////////////////
+	// flush host tag, tagID: 22
+	/////////////////////////
+	for seriesID, host := range hostMapping {
+		for version := uint32(1500000000); version < 1800000000; version += 100000000 {
+			bitmap := roaring.New()
+			bitmap.Add(seriesID)
+			seriesFlusher.FlushVersion(version, version+10000, version+20000, bitmap)
+		}
+		seriesFlusher.FlushTagValue(host)
+	}
+	// pick the hostBlock buffer
+	seriesFlusher.FlushTagKey(22)
+	hostBlock = append(hostBlock, seriesFlusherImpl.entrySetBuffer.Bytes()...)
+	seriesFlusherImpl.reset()
+	return zoneBlock, ipBlock, hostBlock
+}
+
+func buildSeriesIndexReader(ctrl *gomock.Controller) SeriesIndexReader {
+	zoneBlock, ipBlock, hostBlock := buildSeriesIndexBlock(ctrl)
+	// mock readers
+	mockReader := table.NewMockReader(ctrl)
+	mockReader.EXPECT().Get(uint32(19)).Return(nil).AnyTimes()
+	mockReader.EXPECT().Get(uint32(20)).Return(zoneBlock).AnyTimes()
+	mockReader.EXPECT().Get(uint32(21)).Return(ipBlock).AnyTimes()
+	mockReader.EXPECT().Get(uint32(22)).Return(hostBlock).AnyTimes()
+	// mock snapshots
+	mockSnapShot := kv.NewMockSnapshot(ctrl)
+	mockSnapShot.EXPECT().Readers().Return([]table.Reader{mockReader}).AnyTimes()
+	// build series index reader
+	return NewSeriesIndexReader(mockSnapShot)
+}
+
+func Test_SeriesIndexReader_GetSeriesIDsForTagID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	reader := buildSeriesIndexReader(ctrl)
+	// read not tagID key
+	idSet, err := reader.GetSeriesIDsForTagID(19, timeutil.TimeRange{})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+	// read zone block but not overlaps
+	idSet, err = reader.GetSeriesIDsForTagID(20,
+		timeutil.TimeRange{
+			Start: 1400000000 * 1000,
+			End:   1500000000 * 1000})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+	// read zone block, overlaps
+	idSet, err = reader.GetSeriesIDsForTagID(20,
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000})
+	assert.Nil(t, err)
+	assert.NotNil(t, idSet)
+
+	assert.Contains(t, idSet.Versions(), uint32(1500000000))
+	assert.Equal(t, uint32(1), idSet.Versions()[1500000000].Minimum())
+	assert.Equal(t, uint32(9), idSet.Versions()[1500000000].Maximum())
+}
+
+func Test_intSliceContains(t *testing.T) {
+	assert.False(t, intSliceContains(nil, 1))
+	assert.False(t, intSliceContains([]int{1, 3, 4, 5, 8}, 0))
+	assert.True(t, intSliceContains([]int{1, 3, 4, 5, 8}, 1))
+	assert.False(t, intSliceContains([]int{1, 3, 4, 5, 8}, 2))
+	assert.True(t, intSliceContains([]int{1, 3, 4, 5, 8}, 3))
+	assert.True(t, intSliceContains([]int{1, 3, 4, 5, 8}, 8))
+	assert.False(t, intSliceContains([]int{1, 3, 4, 5, 8}, 9))
+}
+
+func Test_SeriesIndexReader_FindSeriesIDsByExprForTagID_badCase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	reader := buildSeriesIndexReader(ctrl)
+
+	// tagID not exist
+	idSet, err := reader.FindSeriesIDsByExprForTagID(19, nil, timeutil.TimeRange{})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+
+	// find zone with bad expression
+	idSet, err = reader.FindSeriesIDsByExprForTagID(20, nil,
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+	// find zone with bad time range
+	idSet, err = reader.FindSeriesIDsByExprForTagID(20, nil,
+		timeutil.TimeRange{Start: 12 * 1000, End: 13 * 1000})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+}
+func Test_SeriesIndexReader_FindSeriesIDsByExprForTagID_EqualExpr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+
+	idSet, err := reader.FindSeriesIDsByExprForTagID(22, &stmt.EqualsExpr{Key: "host", Value: "eleme-dev-sh-4"},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.Nil(t, err)
+	assert.Contains(t, idSet.Versions(), uint32(1500000000))
+	assert.Equal(t, uint64(1), idSet.Versions()[1500000000].GetCardinality())
+	assert.True(t, idSet.Versions()[1500000000].Contains(4))
+	// find not existed host
+	_, err = reader.FindSeriesIDsByExprForTagID(22, &stmt.EqualsExpr{Key: "host", Value: "eleme-dev-sh-41"},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.NotNil(t, err)
+}
+
+func Test_SeriesIndexReader_FindSeriesIDsByExprForTagID_InExpr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+
+	// find existed host
+	idSet, err := reader.FindSeriesIDsByExprForTagID(22, &stmt.InExpr{
+		Key: "host", Values: []string{"eleme-dev-sh-4", "eleme-dev-sh-5", "eleme-dev-sh-55"}},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.Nil(t, err)
+	assert.Contains(t, idSet.Versions(), uint32(1500000000))
+	assert.Equal(t, uint64(2), idSet.Versions()[1500000000].GetCardinality())
+	assert.True(t, idSet.Versions()[1500000000].Contains(4))
+	assert.True(t, idSet.Versions()[1500000000].Contains(5))
+	// find not existed host
+	_, err = reader.FindSeriesIDsByExprForTagID(22, &stmt.InExpr{
+		Key: "host", Values: []string{"eleme-dev-sh-55"}},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.NotNil(t, err)
+}
+
+func Test_SeriesIndexReader_FindSeriesIDsByExprForTagID_LikeExpr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+
+	// find existed host
+	idSet, err := reader.FindSeriesIDsByExprForTagID(22, &stmt.LikeExpr{
+		Key: "host", Value: "eleme-dev-sh-"},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.Nil(t, err)
+	assert.Contains(t, idSet.Versions(), uint32(1500000000))
+	assert.Equal(t, uint64(3), idSet.Versions()[1500000000].GetCardinality())
+	assert.Equal(t, uint32(4), idSet.Versions()[1500000000].Minimum())
+	assert.Equal(t, uint32(6), idSet.Versions()[1500000000].Maximum())
+	// find not existed host
+	_, err = reader.FindSeriesIDsByExprForTagID(22, &stmt.InExpr{
+		Key: "host", Values: []string{"eleme-dev-sh---"}},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.NotNil(t, err)
+}
+
+func Test_SeriesIndexReader_FindSeriesIDsByExprForTagID_RegexExpr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+
+	_, err := reader.FindSeriesIDsByExprForTagID(22, &stmt.RegexExpr{
+		Key: "host", Regexp: "eleme-dev-sh-"},
+		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
+	assert.NotNil(t, err)
+}
+
+func Test_SeriesIndexReader_GetTagValues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+
+	tagValues, err := reader.GetTagValues(1, []string{"host"}, 1500000000)
+	assert.Nil(t, err)
 	assert.Nil(t, tagValues)
-	assert.Nil(t, err)
+}
 
-	// FindSeriesIDsByExpr
-	set, err := reader.FindSeriesIDsByExpr(1, nil, timeutil.TimeRange{})
-	assert.Nil(t, set)
-	assert.Nil(t, err)
+func Test_SeriesIndexReader_entrySetBlockToIDSet_error_cases(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+	readerImpl := reader.(*seriesIndexReader)
+	// block length too short, 8 bytes
+	_, err := readerImpl.entrySetBlockToIDSet(
+		[]byte{16, 86, 104, 89, 32, 63, 84, 101},
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000}, nil)
+	assert.NotNil(t, err)
+	// read tagValue Count failed
+	_, err = readerImpl.entrySetBlockToIDSet(
+		[]byte{16, 86, 104, 89, 32, 63, 84, 101, 1, 1, 0},
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000}, nil)
+	assert.NotNil(t, err)
+	// read dataLen failed
+	_, err = readerImpl.entrySetBlockToIDSet(
+		[]byte{16, 86, 104, 89, 32, 63, 84, 101, 1, 1, 1},
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000}, nil)
+	assert.NotNil(t, err)
+	// offsets is nil
+	_, _, hostBlock := buildSeriesIndexBlock(ctrl)
+	_, err = readerImpl.entrySetBlockToIDSet(
+		hostBlock,
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000}, []int{10, 11, 12})
+	assert.NotNil(t, err)
+}
 
-	// GetSeriesIDsForTag
-	set, err = reader.GetSeriesIDsForTag(1, "", timeutil.TimeRange{})
-	assert.Nil(t, set)
-	assert.Nil(t, err)
+func Test_SeriesIndexReader_readTagValueDataBlock_error_cases(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+	readerImpl := reader.(*seriesIndexReader)
+
+	// validation of length failed
+	idSet, err := readerImpl.readTagValueDataBlock(nil, 10, timeutil.TimeRange{})
+	assert.NotNil(t, err)
+	assert.Nil(t, idSet)
+
+	// read versionCount failed
+	_, err = readerImpl.readTagValueDataBlock([]byte{0}, 0, timeutil.TimeRange{})
+	assert.NotNil(t, err)
+
+	// read version block failed
+	_, err = readerImpl.readTagValueDataBlock([]byte{1, 0}, 0, timeutil.TimeRange{})
+	assert.NotNil(t, err)
+}
+
+func Test_SeriesIndexReader_entrySetBlockToTreeQuerier_error_cases(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	reader := buildSeriesIndexReader(ctrl)
+	readerImpl := reader.(*seriesIndexReader)
+
+	// read stream eof
+	_, err := readerImpl.entrySetBlockToTreeQuerier(
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1})
+	assert.NotNil(t, err)
+
+	// failed validation of trie tree
+	_, err = readerImpl.entrySetBlockToTreeQuerier(
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1, 1, 1})
+	assert.NotNil(t, err)
+
+	// LOUDS block unmarshal failed
+	_, err = readerImpl.entrySetBlockToTreeQuerier(
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 6, 1, 1, 1, 1, 1, 1})
+	assert.NotNil(t, err)
+
+	// isPrefixKey block unmarshal failed
+	out, _ := NewRankSelect().MarshalBinary()
+	badBLOCK := append([]byte{1, 2, 3, 4, 5, 6, 7, 8,
+		18,   // trie tree length
+		1, 1, // labels
+		1, 1, // is prefix
+		13}) // louds
+	badBLOCK = append(badBLOCK, out...) // LOUDS block
+	_, err = readerImpl.entrySetBlockToTreeQuerier(badBLOCK)
+	assert.NotNil(t, err)
 }

--- a/tsdb/indextbl/series_trie_tree.go
+++ b/tsdb/indextbl/series_trie_tree.go
@@ -3,8 +3,6 @@ package indextbl
 import (
 	"sort"
 	"sync"
-
-	"github.com/RoaringBitmap/roaring"
 )
 
 // Implementation of an R-way Trie data structure.
@@ -19,43 +17,43 @@ import (
 
 //go:generate mockgen -source ./series_trie_tree.go -destination=./series_trie_tree_mock.go -package indextbl
 
-// trieTreeINTF abstract a trie tree in memory.
+// trieTreeBuilder abstract a trie tree in memory.
 // All the descendants of a trieTreeNode have a common prefix of the string associated with that trieTreeNode,
 // and the root trieTreeNode is associated with the empty string.
-type trieTreeINTF interface {
-	// Add adds the tagValue and bitmap to the Trie with the id
-	Add(tagValue string, version int64, bitmap *roaring.Bitmap)
+type trieTreeBuilder interface {
+	// Add adds the tagValue and item to the tree
+	Add(tagValue string, item interface{})
 	// NodeNum returns the size of trieTreeNodes
 	NodeNum() int
 	// KeyNum returns the size of keys
 	KeyNum() int
 	// MarshalBinary marshals the trie tree to LOUDS encoded binary.
-	MarshalBinary() *seriesBinData
+	MarshalBinary() *trieTreeData
 	// Reset returns the trieTreeNodes to the pool for reuse.
 	Reset()
 }
 
-// trieTree implements the trieTreeINTF interface.
+// trieTree implements the trieTreeBuilder interface.
 // Not thread-safe
 type trieTree struct {
-	pool            sync.Pool
-	root            *trieTreeNode
-	trieTreeNodeNum int             // count of trieTreeNodes
-	keyNum          int             // count of keys
-	nodesBuf1       []*trieTreeNode // buffering trieTreeNodes for Breadth first search
-	nodesBuf2       []*trieTreeNode // buffering trieTreeNodes for Breadth first search
-	bin             *seriesBinData  // binary
+	pool      sync.Pool
+	root      *trieTreeNode
+	nodeNum   int             // count of trieTreeNodes
+	keyNum    int             // count of keys
+	nodesBuf1 []*trieTreeNode // buffering trieTreeNodes for Breadth first search
+	nodesBuf2 []*trieTreeNode // buffering trieTreeNodes for Breadth first search
+	treeData  *trieTreeData   // binary
 }
 
 // newTrieTree returns an empty trie tree.
-func newTrieTree() trieTreeINTF {
+func newTrieTree() trieTreeBuilder {
 	tt := &trieTree{
 		pool:      sync.Pool{New: func() interface{} { return &trieTreeNode{} }},
 		nodesBuf1: make([]*trieTreeNode, 0, 4096),
 		nodesBuf2: make([]*trieTreeNode, 0, 4096),
 	}
 	tt.root = tt.newNode() // empty string
-	tt.bin = new(seriesBinData)
+	tt.treeData = new(trieTreeData)
 	return tt
 }
 
@@ -66,45 +64,12 @@ func (n trieTreeNodes) Len() int           { return len(n) }
 func (n trieTreeNodes) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n trieTreeNodes) Less(i, j int) bool { return n[i].label < n[j].label }
 
-// versionedBitmap is the trieTreeNode value
-type versionedBitmap struct {
-	version int64
-	bitmap  *roaring.Bitmap
-}
-
-// versionedBitmaps implements sort.Interface
-type versionedBitmaps []versionedBitmap
-
-func (n versionedBitmaps) Len() int           { return len(n) }
-func (n versionedBitmaps) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
-func (n versionedBitmaps) Less(i, j int) bool { return n[i].version < n[j].version }
-
-func (n *versionedBitmaps) insert(version int64, bitmap *roaring.Bitmap) {
-	idx := sort.Search(len(*n), func(i int) bool { return (*n)[i].version >= version })
-	// existed before
-	if idx < len(*n) && (*n)[idx].version == version {
-		(*n)[idx].bitmap = bitmap
-		return
-	}
-	vb := versionedBitmap{version: version, bitmap: bitmap}
-	*n = append(*n, vb)
-	sort.Sort(*n)
-}
-
-// reset set the bitmap pointer and slice length
-func (n *versionedBitmaps) reset() {
-	for _, item := range *n {
-		item.bitmap = nil
-	}
-	*n = (*n)[:0]
-}
-
 // trieTreeNode is the tree trieTreeNode of the trie
 type trieTreeNode struct {
 	label       byte
-	values      versionedBitmaps // versioned bitmap slice
-	isPrefixKey bool             // isPrefixKey indicates if this prefix a valid key
-	children    trieTreeNodes    // sorted children trieTreeNodes list
+	value       interface{}   // versioned bitmap slice
+	isPrefixKey bool          // isPrefixKey indicates if this prefix a valid key
+	children    trieTreeNodes // sorted children trieTreeNodes list
 }
 
 // newNode returns a trieTreeNode with default value
@@ -112,8 +77,8 @@ func (tt *trieTree) newNode() *trieTreeNode {
 	return tt.pool.Get().(*trieTreeNode)
 }
 
-// Add adds a new key to the tree with id.
-func (tt *trieTree) Add(tagValue string, version int64, bitmap *roaring.Bitmap) {
+// Add adds a new key to the tree.
+func (tt *trieTree) Add(tagValue string, item interface{}) {
 	if tagValue == "" {
 		return
 	}
@@ -131,68 +96,69 @@ func (tt *trieTree) Add(tagValue string, version int64, bitmap *roaring.Bitmap) 
 			n.children = append(n.children, theNewNode)
 			sort.Sort(n.children)
 			n = theNewNode
-			tt.trieTreeNodeNum++
+			tt.nodeNum++
 		}
 	}
 	if !n.isPrefixKey {
 		tt.keyNum++
 	}
 	// set the term trieTreeNode
-	n.values.insert(version, bitmap)
+	n.value = item
 	n.isPrefixKey = true
 }
 
 // NodeNum returns the size of trieTreeNodes
-func (tt *trieTree) NodeNum() int { return tt.trieTreeNodeNum }
+func (tt *trieTree) NodeNum() int { return tt.nodeNum }
 
 // KeyNum returns the size of keys
 func (tt *trieTree) KeyNum() int { return tt.keyNum }
 
-// seriesBinData is a LOUDS Encoded trie
-type seriesBinData struct {
-	LOUDS       RSINTF
-	isPrefixKey RSINTF
-	labels      []byte
-	values      []versionedBitmaps
+// trieTreeData is a LOUDS Encoded trie tree with values
+type trieTreeData struct {
+	trieTreeBlock
+	values []interface{}
 }
 
-func (lb *seriesBinData) reset() {
+func (lb *trieTreeData) reset() {
 	lb.LOUDS = nil
 	lb.isPrefixKey = nil
 	lb.labels = lb.labels[:0]
-	for _, vb := range lb.values {
-		vb.reset()
+	for idx := range lb.values {
+		lb.values[idx] = nil
 	}
 	lb.values = lb.values[:0]
 }
 
 // MarshalBinary marshals the trie tree to LOUDS encoded binary.
-func (tt *trieTree) MarshalBinary() *seriesBinData {
-	tt.bin.LOUDS = NewRankSelect()
-	tt.bin.isPrefixKey = NewRankSelect()
+func (tt *trieTree) MarshalBinary() *trieTreeData {
+	tt.treeData.LOUDS = NewRankSelect()
+	tt.treeData.isPrefixKey = NewRankSelect()
 	tt.nodesBuf1 = []*trieTreeNode{tt.root}
 
-	tt.bin.LOUDS.PushPseudoRoot()
+	// for easier indexing
+	tt.treeData.LOUDS.PushPseudoRoot()
+	tt.treeData.isPrefixKey.PushBack(false)
+	tt.treeData.labels = append(tt.treeData.labels, byte(0))
 
 	for len(tt.nodesBuf1) > 0 {
 		for _, trieTreeNode := range tt.nodesBuf1 {
 			if trieTreeNode.isPrefixKey {
-				tt.bin.values = append(tt.bin.values, trieTreeNode.values)
+				tt.treeData.values = append(tt.treeData.values, trieTreeNode.value)
 			}
-			tt.bin.isPrefixKey.PushBack(trieTreeNode.isPrefixKey)
-			tt.bin.labels = append(tt.bin.labels, trieTreeNode.label)
+			tt.treeData.isPrefixKey.PushBack(trieTreeNode.isPrefixKey)
+			tt.treeData.labels = append(tt.treeData.labels, trieTreeNode.label)
 
 			for _, trieTreeNode := range trieTreeNode.children {
 				tt.nodesBuf2 = append(tt.nodesBuf2, trieTreeNode)
-				tt.bin.LOUDS.PushBack(true)
+				tt.treeData.LOUDS.PushBack(true)
 			}
-			tt.bin.LOUDS.PushBack(false)
+			tt.treeData.LOUDS.PushBack(false)
 		}
 		// copy
 		tt.nodesBuf1 = append(tt.nodesBuf1[:0], tt.nodesBuf2...)
 		tt.nodesBuf2 = tt.nodesBuf2[:0]
 	}
-	return tt.bin
+	return tt.treeData
 }
 
 // Reset returns the trieTreeNodes to the underlying pool for reuse.
@@ -205,7 +171,7 @@ func (tt *trieTree) Reset() {
 			for _, child := range n.children {
 				tt.nodesBuf2 = append(tt.nodesBuf2, child)
 			}
-			n.values.reset()
+			n.value = nil
 			n.isPrefixKey = false
 			n.label = byte(0)
 			n.children = n.children[:0]
@@ -214,10 +180,120 @@ func (tt *trieTree) Reset() {
 		tt.nodesBuf1 = append(tt.nodesBuf1[:0], tt.nodesBuf2...)
 		tt.nodesBuf2 = tt.nodesBuf2[:0]
 	}
-	tt.bin.reset()
+	tt.treeData.reset()
 	tt.root = tt.newNode()
 	tt.keyNum = 0
-	tt.trieTreeNodeNum = 0
+	tt.nodeNum = 0
 	tt.nodesBuf1 = tt.nodesBuf1[:0]
 	tt.nodesBuf2 = tt.nodesBuf2[:0]
 }
+
+// trieTreeQuerier represents the ability for querying data-block offsets from the trie-tree
+type trieTreeQuerier interface {
+	// FindOffsetsByEqual find offsets of prefixKeys which equals to the value in the tree
+	FindOffsetsByEqual(value string) (offsets []int)
+	// FindOffsetsByIn find offsets of prefixKeys which in the value list in the tree
+	FindOffsetsByIn(values []string) (offsets []int)
+	// FindOffsetsByLike find offsets of prefixKeys which is like the value in the tree
+	FindOffsetsByLike(value string) (offsets []int)
+	// FindOffsetsByRegex find offsets of prefixKeys which regex matches the pattern in the tree
+	FindOffsetsByRegex(pattern string) (offsets []int)
+}
+
+// trieTreeBlock is the structured trie-tree-block of series-index-table
+// trieTreeBlock implements trieTreeQuerier
+type trieTreeBlock struct {
+	labels      []byte
+	isPrefixKey RSINTF
+	LOUDS       RSINTF
+}
+
+func (block *trieTreeBlock) FindOffsetsByEqual(value string) (offsets []int) {
+	exhausted, nodeNumber := block.walkTreeByValue(value)
+	if exhausted && block.isPrefixKey.Bit(nodeNumber) {
+		return []int{int(block.isPrefixKey.Rank1(nodeNumber) - 1)}
+	}
+	return
+}
+
+// walkTreeByValue walks on the tree and exhaust the char in the value
+// if all chars are exhausted, it will return true
+func (block *trieTreeBlock) walkTreeByValue(value string) (exhausted bool, nodeNumber uint64) {
+	// first available node sequence is 1
+	nodeNumber = 1
+	valueBytes := []byte(value)
+	for idx, v := range valueBytes {
+		firstChildNumber, ok := block.LOUDS.FirstChild(nodeNumber)
+		if !ok {
+			continue
+		}
+		lastChildNumber, ok := block.LOUDS.LastChild(nodeNumber)
+		if !ok {
+			continue
+		}
+		for childNumber := firstChildNumber; childNumber <= lastChildNumber; childNumber++ {
+			// validate labels length
+			if int(childNumber) >= len(block.labels) {
+				return false, nodeNumber
+			}
+			if block.labels[int(childNumber)] == v {
+				nodeNumber = childNumber
+				break
+			}
+		}
+		if idx == len(valueBytes)-1 {
+			exhausted = true
+		}
+	}
+	return
+}
+
+func (block *trieTreeBlock) FindOffsetsByIn(values []string) (offsets []int) {
+	for _, value := range values {
+		eachOffsets := block.FindOffsetsByEqual(value)
+		if eachOffsets != nil {
+			offsets = append(offsets, eachOffsets...)
+		}
+	}
+	return
+}
+
+func (block *trieTreeBlock) FindOffsetsByLike(value string) (offsets []int) {
+	exhausted, nodeNumber := block.walkTreeByValue(value)
+	if !exhausted {
+		return nil
+	}
+	// exhausted, check if it is the prefix-key
+	if block.isPrefixKey.Bit(nodeNumber) {
+		offsets = append(offsets, int(block.isPrefixKey.Rank1(nodeNumber)-1))
+	}
+	var (
+		nextNodes = []uint64{nodeNumber}
+		tmpNodes  []uint64
+	)
+	// BFS walk
+	for len(nextNodes) > 0 {
+		for _, node := range nextNodes {
+			firstChildNumber, ok := block.LOUDS.FirstChild(node)
+			if !ok {
+				continue
+			}
+			lastChildNumber, ok := block.LOUDS.LastChild(node)
+			if !ok {
+				continue
+			}
+			for childNumber := firstChildNumber; childNumber <= lastChildNumber; childNumber++ {
+				tmpNodes = append(tmpNodes, childNumber)
+				if block.isPrefixKey.Bit(childNumber) {
+					offsets = append(offsets, int(block.isPrefixKey.Rank1(childNumber)-1))
+				}
+			}
+		}
+		nextNodes = append(nextNodes[:0], tmpNodes...)
+		tmpNodes = tmpNodes[:0]
+	}
+	return offsets
+}
+
+// todo: @codingcrush, implementation, traverse the values by forward index?
+func (block *trieTreeBlock) FindOffsetsByRegex(pattern string) (offsets []int) { return nil }

--- a/tsdb/indextbl/series_trie_tree_test.go
+++ b/tsdb/indextbl/series_trie_tree_test.go
@@ -3,7 +3,6 @@ package indextbl
 import (
 	"testing"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,40 +10,35 @@ func Test_trie_tree(t *testing.T) {
 	tree := newTrieTree()
 	assert.NotNil(t, tree)
 
-	bitmap1 := roaring.New()
-	bitmap1.AddRange(1, 100)
-	tree.Add("football", 1, bitmap1)
-	tree.Add("football", 11, bitmap1)
-	tree.Add("football", 121, bitmap1)
+	tree.Add("football", nil)
+	tree.Add("football", nil)
+	tree.Add("football", nil)
 	assert.Equal(t, 1, tree.KeyNum())
 	assert.Equal(t, 8, tree.NodeNum())
 
-	bitmap2 := roaring.New()
-	bitmap2.AddRange(323, 400)
-
-	tree.Add("foo", 2, bitmap2)
+	tree.Add("foo", nil)
 	assert.Equal(t, 2, tree.KeyNum())
 	assert.Equal(t, 8, tree.NodeNum())
 
-	tree.Add("f", 344, roaring.New())
-	tree.Add("fo", 45, roaring.New())
+	tree.Add("f", 1)
+	tree.Add("fo", 2)
 	assert.Equal(t, 4, tree.KeyNum())
 	assert.Equal(t, 8, tree.NodeNum())
 
-	tree.Add("feet", 45, roaring.New())
+	tree.Add("feet", 3)
 	assert.Equal(t, 5, tree.KeyNum())
 	assert.Equal(t, 11, tree.NodeNum())
 
-	tree.Add("bike", 4, roaring.New())
-	tree.Add("bike.bke", 5, roaring.New())
+	tree.Add("bike", 4)
+	tree.Add("bike.bke", 5)
 
-	tree.Add("a", 6, roaring.New())
-	tree.Add("ab", 7, roaring.New())
-	tree.Add("abcd", 8, roaring.New())
+	tree.Add("a", 6)
+	tree.Add("ab", 7)
+	tree.Add("abcd", 8)
 	assert.Equal(t, 10, tree.KeyNum())
 	assert.Equal(t, 23, tree.NodeNum())
 
-	tree.Add("", 323333, roaring.New())
+	tree.Add("", 323333)
 	assert.Equal(t, 10, tree.KeyNum())
 	assert.Equal(t, 23, tree.NodeNum())
 
@@ -55,8 +49,8 @@ func Test_trie_tree(t *testing.T) {
 
 func Test_trie_MarshalBinary(t *testing.T) {
 	tree := newTrieTree()
-	tree.Add("hello", 9, roaring.New())
-	tree.Add("world", 12, roaring.New())
+	tree.Add("hello", 9)
+	tree.Add("world", 12)
 
 	tree.Reset()
 	trie := tree.(*trieTree)
@@ -64,45 +58,95 @@ func Test_trie_MarshalBinary(t *testing.T) {
 	assert.Len(t, trie.nodesBuf2, 0)
 	assert.Len(t, trie.root.children, 0)
 
-	tree.Add("eleme", 1, roaring.New())
-	tree.Add("eleme", 1, roaring.New())
-	tree.Add("eleme", 3, roaring.New())
-	tree.Add("eleme", 2, roaring.New())
+	tree.Add("eleme", 1)
+	tree.Add("eleme", 1)
+	tree.Add("eleme", 3)
+	tree.Add("eleme", 2)
 
-	tree.Add("eleme.ci", 2, roaring.New())
-	tree.Add("eleme.ci.etrace", 3, roaring.New())
-	tree.Add("eleme.bdi", 4, roaring.New())
-	tree.Add("eleme.other", 5, roaring.New())
-	tree.Add("etrace", 6, roaring.New())
-	tree.Add("java", 7, roaring.New())
-	tree.Add("javascript", 8, roaring.New())
-	tree.Add("j", 9, roaring.New())
+	tree.Add("eleme.ci", 2)
+	tree.Add("eleme.ci.etrace", 3)
+	tree.Add("eleme.bdi", 4)
+	tree.Add("eleme.other", 5)
+	tree.Add("etrace", 6)
+	tree.Add("java", 7)
+	tree.Add("javascript", 8)
+	tree.Add("j", 9)
 
 	bin := tree.MarshalBinary()
 	assert.NotNil(t, bin)
 
-	assert.Equal(t, "ejltaervmaaecs.ecbcorditii.hpeettrrace", string(bin.labels)[1:])
+	assert.Equal(t, "ejltaervmaaecs.ecbcorditii.hpeettrrace", string(bin.labels)[2:])
 	assert.Len(t, bin.values, 9)
 
 	tree.Reset()
 }
 
-func Benchmark_MarshalBinary(b *testing.B) {
+func Benchmark_trie_MarshalBinary(b *testing.B) {
 	tree := newTrieTree()
-	rb := roaring.New()
 
 	for i := 0; i < b.N; i++ {
-		tree.Add("eleme", 1, rb)
-		tree.Add("eleme.ci", 2, rb)
-		tree.Add("eleme.ci.etrace", 3, rb)
-		tree.Add("eleme.bdi", 4, rb)
-		tree.Add("eleme.other", 5, rb)
-		tree.Add("etrace", 6, rb)
-		tree.Add("java", 7, rb)
-		tree.Add("javascript", 8, rb)
-		tree.Add("j", 9, rb)
+		tree.Add("eleme", 1)
+		tree.Add("eleme.ci", 2)
+		tree.Add("eleme.ci.etrace", 3)
+		tree.Add("eleme.bdi", 4)
+		tree.Add("eleme.other", 5)
+		tree.Add("etrace", 6)
+		tree.Add("java", 7)
+		tree.Add("javascript", 8)
+		tree.Add("j", 9)
 
 		tree.MarshalBinary()
 		tree.Reset()
 	}
+}
+
+func Test_trieTreeQuerier(t *testing.T) {
+	/*
+		c5   e      f
+		d6   l   t  i
+		   e  c  r  r
+		   m  d2 a  e
+		   e1    c  f
+		         e3 o
+		            x4
+
+		values : 5,2,1,3,4
+		indexes: 0,1,2,3,4
+	*/
+
+	tree := newTrieTree()
+	tree.Add("eleme", 1)   // index: 3
+	tree.Add("etcd", 2)    // index: 2
+	tree.Add("etrace", 3)  // index: 4
+	tree.Add("firefox", 4) // index: 5
+	tree.Add("c", 5)       // index: 0
+	tree.Add("cd", 6)      // index: 1
+
+	data := tree.MarshalBinary()
+	// test FindOffsetsByEqual
+	assert.Equal(t, []int{3}, data.FindOffsetsByEqual("eleme"))
+	assert.Equal(t, []int{2}, data.FindOffsetsByEqual("etcd"))
+	assert.Equal(t, []int{4}, data.FindOffsetsByEqual("etrace"))
+	assert.Equal(t, []int{5}, data.FindOffsetsByEqual("firefox"))
+	assert.Equal(t, []int{0}, data.FindOffsetsByEqual("c"))
+	assert.Equal(t, []int{1}, data.FindOffsetsByEqual("cd"))
+	assert.Len(t, data.FindOffsetsByEqual("d"), 0)
+	assert.Len(t, data.FindOffsetsByEqual("et"), 0)
+	assert.Len(t, data.FindOffsetsByEqual("etcd1"), 0)
+	assert.Len(t, data.FindOffsetsByEqual("fire"), 0)
+	assert.Len(t, data.FindOffsetsByEqual("etrac"), 0)
+
+	// test FindOffsetsByIn
+	assert.Len(t, data.FindOffsetsByIn([]string{"d", "c"}), 1)
+	assert.Equal(t, []int{0}, data.FindOffsetsByIn([]string{"d", "c"}))
+	assert.Equal(t, []int{3, 2}, data.FindOffsetsByIn([]string{"eleme", "etcd"}))
+	assert.Equal(t, []int{4, 5}, data.FindOffsetsByIn([]string{"etrace", "etrace1", "firefox"}))
+
+	// test FindOffsetsByLike
+	assert.Equal(t, []int{0, 1}, data.FindOffsetsByLike("c"))
+	assert.Equal(t, []int{1}, data.FindOffsetsByLike("cd"))
+	assert.Equal(t, []int{2, 4}, data.FindOffsetsByLike("et"))
+	assert.Equal(t, []int{5}, data.FindOffsetsByLike("fire"))
+	assert.Nil(t, data.FindOffsetsByLike(""))
+	assert.Nil(t, data.FindOffsetsByLike("etrace1"))
 }

--- a/tsdb/memdb/constants.go
+++ b/tsdb/memdb/constants.go
@@ -7,8 +7,8 @@ const (
 	shardingCountOfMStores = 2 << 4
 	// mask for calculating sharding-index by AND
 	shardingCountMask = shardingCountOfMStores - 1
-	// unit: millisecond, used to prevent resetting metric-store too frequently.
-	minIntervalForResetMetricStore = 10 * 1000
+	// unit: seconds, used to prevent resetting metric-store too frequently.
+	minIntervalForResetMetricStore = 10
 )
 
 // use var for mocking

--- a/tsdb/memdb/database_test.go
+++ b/tsdb/memdb/database_test.go
@@ -86,7 +86,7 @@ func Test_MemoryDatabase_setLimitations_countTags_countMetrics_resetMStore(t *te
 
 	mockMStore := NewMockmStoreINTF(ctrl)
 	mockMStore.EXPECT().setMaxTagsLimit(gomock.Any()).Return().AnyTimes()
-	mockMStore.EXPECT().getTagsCount().Return(1).AnyTimes()
+	mockMStore.EXPECT().getTagsUsed().Return(1).AnyTimes()
 	mockMStore.EXPECT().resetVersion().Return(nil).AnyTimes()
 	// setLimitations
 	limitations := map[string]uint32{"cpu.load": 10, "memory": 100}
@@ -181,8 +181,8 @@ func Test_FindSeriesIDsByExpr_GetSeriesIDsForTag(t *testing.T) {
 	md := mdINTF.(*memoryDatabase)
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().findSeriesIDsByExpr(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	mockMStore.EXPECT().getSeriesIDsForTag("", gomock.Any()).Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().findSeriesIDsByExpr(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().getSeriesIDsForTag("").Return(nil, nil).AnyTimes()
 	// not exist
 	_, err := md.FindSeriesIDsByExpr(1, nil, timeutil.TimeRange{})
 	assert.NotNil(t, err)
@@ -245,8 +245,8 @@ func Test_FlushSeriesIndexTo(t *testing.T) {
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
 	gomock.InOrder(
-		mockMStore.EXPECT().flushIndexesTo(gomock.Any(), gomock.Any()).Return(nil),
-		mockMStore.EXPECT().flushIndexesTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")),
+		mockMStore.EXPECT().flushSeriesIndexesTo(gomock.Any(), gomock.Any()).Return(nil),
+		mockMStore.EXPECT().flushSeriesIndexesTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")),
 	)
 	// insert to bucket
 	md.getBucket(4).hash2MStore[1] = mockMStore

--- a/tsdb/memdb/metric_store_index_test.go
+++ b/tsdb/memdb/metric_store_index_test.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lindb/lindb/tsdb/series"
-
 	"github.com/lindb/lindb/pkg/timeutil"
 	"github.com/lindb/lindb/sql/stmt"
 	"github.com/lindb/lindb/tsdb/metrictbl"
+	"github.com/lindb/lindb/tsdb/series"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -49,7 +47,7 @@ func Test_tagIndex_tStore_get(t *testing.T) {
 	tagIdxInterface.getOrCreateTStore("h=33")
 
 	// getTagKVEntrySet test
-	assert.NotNil(t, tagIdxInterface.getTagKVEntrySet())
+	assert.NotNil(t, tagIdxInterface.getTagKVEntrySets())
 }
 
 func Test_tagIndex_tStore_error(t *testing.T) {
@@ -59,14 +57,17 @@ func Test_tagIndex_tStore_error(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		_, _ = tagIdx.getOrCreateTStore(fmt.Sprintf("%d=%d", i, i))
 	}
-	assert.Equal(t, 512, tagIdx.len())
+	assert.Equal(t, 512, tagIdx.tagsUsed())
 	_, err := tagIdxInterface.getOrCreateTStore("zone=nj")
 	assert.Equal(t, series.ErrTooManyTagKeys, err)
-	assert.Equal(t, 512, tagIdx.len())
+	assert.Equal(t, 512, tagIdx.tagsUsed())
 	// remove tStores
 	tagIdx.removeTStores()
-	tagIdx.removeTStores(1, 2, 3, 4)
-	assert.Equal(t, 508, tagIdx.len())
+	tagIdx.removeTStores(1, 2, 3, 4, 1003)
+	// used tags won't change
+	assert.Equal(t, 512, tagIdx.tagsUsed())
+	// in use tags was removed
+	assert.Equal(t, 508, tagIdx.tagsInUse())
 	// allTStores
 	assert.NotNil(t, tagIdxInterface.allTStores())
 }
@@ -116,16 +117,7 @@ func prepareTagIdx(ctrl *gomock.Controller) tagIndexINTF {
 	for seriesID, tStore := range tagIdx.seriesID2TStore {
 		mockTStore := NewMocktStoreINTF(ctrl)
 		mockTStore.EXPECT().getHash().Return(tStore.getHash()).AnyTimes()
-
-		var newStore tStoreINTF
-		if seriesID == 4 {
-			mockTStore.EXPECT().timeRange().Return(timeutil.TimeRange{Start: 0, End: 0}, false).AnyTimes()
-			newStore = mockTStore
-		} else {
-			mockTStore.EXPECT().timeRange().Return(timeutil.TimeRange{Start: 1000, End: 2000}, true).AnyTimes()
-			newStore = mockTStore
-		}
-		newMap[seriesID] = newStore
+		newMap[seriesID] = mockTStore
 	}
 
 	tagIdx.seriesID2TStore = newMap
@@ -138,30 +130,17 @@ func Test_tagIndex_findSeriesIDsByEqual(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// tag-key not exist
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.EqualsExpr{Key: "not-exist-key", Value: "alpha"},
-		timeutil.TimeRange{Start: 0, End: 0})
+	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "not-exist-key", Value: "alpha"})
 	assert.Nil(t, bitmap)
 	// tag-value not exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.EqualsExpr{Key: "host", Value: "alpha"},
-		timeutil.TimeRange{Start: 1, End: 100})
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "alpha"})
 	assert.Nil(t, bitmap)
-	// tag-value exist, time-range not ok
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.EqualsExpr{Key: "host", Value: "c"},
-		timeutil.TimeRange{Start: 1, End: 100})
+	// tag-value exist
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "c"})
 	assert.NotNil(t, bitmap)
-	assert.Zero(t, bitmap.GetCardinality())
-	// tag-value exist, time-range ok, not overlaps
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.EqualsExpr{Key: "host", Value: "b"},
-		timeutil.TimeRange{Start: 1, End: 150})
-	assert.Zero(t, bitmap.GetCardinality())
-	// tag-value exist, time-range ok, overlaps
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.EqualsExpr{Key: "host", Value: "bc"},
-		timeutil.TimeRange{Start: 1000, End: 1500})
+	assert.Equal(t, uint64(1), bitmap.GetCardinality())
+	// tag-value exist
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "bc"})
 	assert.Equal(t, uint64(1), bitmap.GetCardinality())
 }
 
@@ -170,15 +149,8 @@ func Test_tagIndex_findSeriesIDsByIn(t *testing.T) {
 	defer ctrl.Finish()
 	tagIdxInterface := prepareTagIdx(ctrl)
 
-	// tag-value exist, time-range ok, not overlaps
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.InExpr{Key: "host", Values: []string{"b", "bc", "bcd", "ahi"}},
-		timeutil.TimeRange{Start: 1, End: 150})
-	assert.Zero(t, bitmap.GetCardinality())
-	// tag-value exist, time-range ok, overlaps
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.InExpr{Key: "host", Values: []string{"b", "bc", "bcd", "ahi"}},
-		timeutil.TimeRange{Start: 1000, End: 1500})
+	// tag-value exist
+	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.InExpr{Key: "host", Values: []string{"b", "bc", "bcd", "ahi"}})
 	assert.Equal(t, uint64(3), bitmap.GetCardinality())
 }
 
@@ -187,20 +159,14 @@ func Test_tagIndex_findSeriesIDsByLike(t *testing.T) {
 	defer ctrl.Finish()
 	tagIdxInterface := prepareTagIdx(ctrl)
 
-	// tag-value exist, time-range ok, not overlaps
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.LikeExpr{Key: "host", Value: "bc"},
-		timeutil.TimeRange{Start: 1, End: 150})
-	assert.Zero(t, bitmap.GetCardinality())
-	// tag-value exist, time-range ok, overlaps
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.LikeExpr{Key: "host", Value: "bc"},
-		timeutil.TimeRange{Start: 1000, End: 1500})
+	// tag-value exist
+	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "host", Value: "bc"})
 	assert.Equal(t, uint64(3), bitmap.GetCardinality())
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.LikeExpr{Key: "zone", Value: "s"},
-		timeutil.TimeRange{Start: 1000, End: 1500})
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "s"})
 	assert.Equal(t, uint64(4), bitmap.GetCardinality())
+	// tag-value not exist
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "not-exist"})
+	assert.Zero(t, bitmap.GetCardinality())
 }
 
 func Test_tagIndex_findSeriesIDsByRegex(t *testing.T) {
@@ -208,21 +174,14 @@ func Test_tagIndex_findSeriesIDsByRegex(t *testing.T) {
 	defer ctrl.Finish()
 	tagIdxInterface := prepareTagIdx(ctrl)
 
-	// tag-value exist, time-range ok, not overlaps
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.RegexExpr{Key: "host", Regexp: "b"},
-		timeutil.TimeRange{Start: 1, End: 150})
+	// pattern not match
+	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "bbbbbbbbbbb"})
 	assert.Zero(t, bitmap.GetCardinality())
 	// pattern error
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.RegexExpr{Key: "host", Regexp: "b.32*++++\n"},
-		timeutil.TimeRange{Start: 1, End: 150})
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "b.32*++++\n"})
 	assert.Nil(t, bitmap)
-
-	// tag-value exist, time-range ok, overlaps
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(
-		&stmt.RegexExpr{Key: "host", Regexp: `b2[0-9]+`},
-		timeutil.TimeRange{Start: 1000, End: 1500})
+	// tag-value exist
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `b2[0-9]+`})
 	assert.Equal(t, uint64(2), bitmap.GetCardinality())
 }
 
@@ -232,13 +191,11 @@ func Test_tagIndex_getSeriesIDsForTag(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// not-exist
-	bitmap := tagIdxInterface.getSeriesIDsForTag("not-exist-key",
-		timeutil.TimeRange{Start: 1000, End: 2000})
+	bitmap := tagIdxInterface.getSeriesIDsForTag("not-exist-key")
 	assert.Nil(t, bitmap)
 	// overlap
-	bitmap = tagIdxInterface.getSeriesIDsForTag("host",
-		timeutil.TimeRange{Start: 1000, End: 2000})
-	assert.Equal(t, uint64(7), bitmap.GetCardinality())
+	bitmap = tagIdxInterface.getSeriesIDsForTag("host")
+	assert.Equal(t, uint64(8), bitmap.GetCardinality())
 }
 
 type mockTagKey struct {
@@ -252,15 +209,36 @@ func Test_tagIndex_special_case(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	tagIdxInterface := prepareTagIdx(ctrl)
-	tagIdx := tagIdxInterface.(*tagIndex)
-
 	// test expr type assertion failure
-	assert.Nil(t, tagIdxInterface.findSeriesIDsByExpr(mockTagKey{}, timeutil.TimeRange{}))
+	assert.Nil(t, tagIdxInterface.findSeriesIDsByExpr(mockTagKey{}))
+}
 
-	// test unionBitMap
-	x2 := roaring.New()
-	x2.AddMany([]uint32{1, 2, 3, 8, 9})
-	union := roaring.New()
-	tagIdx.unionBitMap(union, x2, timeutil.TimeRange{Start: 1, End: 1000})
-	assert.Equal(t, uint64(4), union.GetCardinality())
+func Test_TagIndex_recreateEvictedTStores(t *testing.T) {
+	tagIdxInterface := newTagIndex()
+
+	tagIdxInterface.getOrCreateTStore("host=a")
+	tagIdxInterface.getOrCreateTStore("host=a")
+	tagIdxInterface.getOrCreateTStore("host=b")
+	assert.Equal(t, 2, tagIdxInterface.tagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
+	// remove seriesID = 1
+	tagIdxInterface.removeTStores(0, 1)
+	assert.Equal(t, 1, tagIdxInterface.tagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
+	tagIdxInterface.getOrCreateTStore("host=a")
+	assert.Equal(t, 2, tagIdxInterface.tagsInUse())
+	tagIdxInterface.removeTStores(1, 2)
+	assert.Equal(t, 0, tagIdxInterface.tagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
+}
+
+func Test_TagIndex_timeRange(t *testing.T) {
+	tagIdxInterface := newTagIndex()
+	startTime, endTime := tagIdxInterface.getTimeRange()
+	tagIdxInterface.updateTime(uint32(timeutil.Now()/1000 - 10))
+	tagIdxInterface.updateTime(uint32(timeutil.Now()/1000 + 10))
+
+	newStartTime, newEndTime := tagIdxInterface.getTimeRange()
+	assert.True(t, newStartTime < startTime)
+	assert.True(t, newEndTime > endTime)
 }

--- a/tsdb/memdb/segment_store.go
+++ b/tsdb/memdb/segment_store.go
@@ -23,8 +23,8 @@ type sStoreINTF interface {
 // singleFieldStore stores single field
 type simpleFieldStore struct {
 	familyTime int64
-	block      block
 	aggFunc    field.AggFunc
+	block      block
 }
 
 // newSingleFieldStore returns a new segment store for simple field store

--- a/tsdb/memdb/timeseries_store_test.go
+++ b/tsdb/memdb/timeseries_store_test.go
@@ -17,9 +17,7 @@ func Test_newTimeSeriesStore(t *testing.T) {
 	assert.NotNil(t, tStore)
 	assert.True(t, tStore.isNoData())
 	assert.False(t, tStore.isExpired())
-
-	_, ok := tStore.timeRange()
-	assert.False(t, ok)
+	assert.Equal(t, uint64(100), tStore.getHash())
 }
 
 func Test_tStore_expired(t *testing.T) {
@@ -87,21 +85,8 @@ func Test_tStore_afterWrite(t *testing.T) {
 	tStoreInterface := newTimeSeriesStore(100, 100)
 	tStore := tStoreInterface.(*timeSeriesStore)
 
-	writeCtx := writeContext{
-		timeInterval: 10 * 1000,
-		slotIndex:    40,
-		familyTime:   timeutil.Now() / 3600 / 1000 * 3600 * 1000}
-	tStore.afterWrite(writeCtx)
+	tStore.afterWrite()
 	assert.True(t, tStore.hasData)
-	assert.Equal(t, tStore.startDelta, tStore.endDelta)
-	timeRange, _ := tStore.timeRange()
-	assert.Equal(t, timeRange.Start, timeRange.End)
-
-	writeCtx.slotIndex = 380
-	tStore.afterWrite(writeCtx)
-	timeRange, _ = tStore.timeRange()
-	assert.True(t, timeRange.Start < timeRange.End)
-	assert.True(t, timeRange.End > timeutil.Now())
 }
 
 func Test_tStore_flushSeriesTo(t *testing.T) {
@@ -136,8 +121,6 @@ func Test_tStore_flushSeriesTo(t *testing.T) {
 	tStore.insertFStore(mockFStore3)
 	assert.True(t, tStore.flushSeriesTo(mockTF, flushContext{timeInterval: 10 * 1000}))
 	assert.False(t, tStoreInterface.isNoData())
-	timeRange, _ := tStoreInterface.timeRange()
-	assert.Equal(t, int64(70), (timeRange.End-timeRange.Start)/1000)
 
 	// flush error
 	tStore.fStoreNodes = nil

--- a/tsdb/series/error.go
+++ b/tsdb/series/error.go
@@ -2,8 +2,8 @@ package series
 
 import "errors"
 
-// ErrMetaDataNotExist is returned by index-database when the meta-data of metric not exists
-var ErrMetaDataNotExist = errors.New("meta data not exist")
+// ErrNotFound is returned by index-database when the data does not exists on disk
+var ErrNotFound = errors.New("data not found")
 
 // ErrTooManyTags is the error returned by tsdb when
 // writes exceed the max limit of tag identifiers.

--- a/tsdb/series/interface.go
+++ b/tsdb/series/interface.go
@@ -7,10 +7,10 @@ import (
 
 //go:generate mockgen -source ./interface.go -destination=./interface_mock.go -package=series
 
-// MetadataGetter represents the query ability for metric level metadata
-type MetadataGetter interface {
+// MetaGetter represents the query ability for metric level metadata
+type MetaGetter interface {
 	// GetTagValues returns tag values by tag keys and spec version for metric level
-	GetTagValues(metricID uint32, tagKeys []string, version int64) (tagValues [][]string, err error)
+	GetTagValues(metricID uint32, tagKeys []string, version uint32) (tagValues [][]string, err error)
 }
 
 // Filter represents the query ability for filtering seriesIDs by expr from an index of tags.
@@ -23,3 +23,6 @@ type Filter interface {
 	GetSeriesIDsForTag(metricID uint32, tagKey string,
 		timeRange timeutil.TimeRange) (*MultiVerSeriesIDSet, error)
 }
+
+// DataGetter represents the query ability for querying data of the seriesIDs
+type DataGetter interface{}

--- a/tsdb/series/multi_ver.go
+++ b/tsdb/series/multi_ver.go
@@ -2,22 +2,26 @@ package series
 
 import "github.com/RoaringBitmap/roaring"
 
+// Refs:
+// [1]. An Experimental Study of Bitmap Compression vs. Inverted List Compression
+//      http://db.ucsd.edu/wp-content/uploads/2017/03/sidm338-wangA.pdf
+
 // MultiVerSeriesIDSet represents a multi version series ids set, can do and/or/and not operator,
 // NOTICE: stores the result in the current bitmap, not safe for goroutine concurrent.
 // version-> a bitmap of series ids.
 type MultiVerSeriesIDSet struct {
-	versions map[int64]*roaring.Bitmap
+	versions map[uint32]*roaring.Bitmap
 }
 
 // NewMultiVerSeriesIDSet creates a multi-version series id set
 func NewMultiVerSeriesIDSet() *MultiVerSeriesIDSet {
 	return &MultiVerSeriesIDSet{
-		versions: make(map[int64]*roaring.Bitmap),
+		versions: make(map[uint32]*roaring.Bitmap),
 	}
 }
 
 // Add adds a series id set version to map, if version exist ignore new ids
-func (mv *MultiVerSeriesIDSet) Add(version int64, ids *roaring.Bitmap) {
+func (mv *MultiVerSeriesIDSet) Add(version uint32, ids *roaring.Bitmap) {
 	_, ok := mv.versions[version]
 	if !ok {
 		mv.versions[version] = ids
@@ -41,7 +45,7 @@ func (mv *MultiVerSeriesIDSet) IsEmpty() bool {
 // And computes the intersection between two set and stores the result in the current set
 func (mv *MultiVerSeriesIDSet) And(other *MultiVerSeriesIDSet) {
 	// 1. computes the intersection between two version
-	var notExist []int64
+	var notExist []uint32
 	for version := range mv.versions {
 		_, ok := other.versions[version]
 		if !ok {
@@ -78,4 +82,9 @@ func (mv *MultiVerSeriesIDSet) AndNot(other *MultiVerSeriesIDSet) {
 			existIDs.AndNot(ids)
 		}
 	}
+}
+
+// Versions return the different versions bitmap of the set.
+func (mv *MultiVerSeriesIDSet) Versions() map[uint32]*roaring.Bitmap {
+	return mv.versions
 }

--- a/tsdb/series/multi_ver_test.go
+++ b/tsdb/series/multi_ver_test.go
@@ -10,70 +10,71 @@ import (
 func TestMultiVerSeriesIDSet_IsEmpty(t *testing.T) {
 	multiVer1 := NewMultiVerSeriesIDSet()
 	assert.True(t, multiVer1.IsEmpty())
-	multiVer1.Add(int64(12), roaring.BitmapOf())
+	multiVer1.Add(uint32(12), roaring.BitmapOf())
 	assert.True(t, multiVer1.IsEmpty())
 	multiVer1 = NewMultiVerSeriesIDSet()
-	multiVer1.Add(int64(12), roaring.BitmapOf(1, 2, 3, 4, 5))
+	multiVer1.Add(uint32(12), roaring.BitmapOf(1, 2, 3, 4, 5))
 	assert.False(t, multiVer1.IsEmpty())
+	assert.Len(t, multiVer1.Versions(), 1)
 }
 
 func TestMultiVerSeriesIDSet_And(t *testing.T) {
 	multiVer1 := NewMultiVerSeriesIDSet()
-	multiVer1.Add(int64(12), roaring.BitmapOf(1, 2, 3, 4))
+	multiVer1.Add(uint32(12), roaring.BitmapOf(1, 2, 3, 4))
 	// will ignore
-	multiVer1.Add(int64(12), roaring.BitmapOf(1, 2, 3, 4, 5, 6))
-	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4), *(multiVer1.versions[int64(12)]))
+	multiVer1.Add(uint32(12), roaring.BitmapOf(1, 2, 3, 4, 5, 6))
+	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4), *(multiVer1.versions[uint32(12)]))
 
 	multiVer2 := NewMultiVerSeriesIDSet()
-	multiVer2.Add(int64(12), roaring.BitmapOf(2, 3, 4))
+	multiVer2.Add(uint32(12), roaring.BitmapOf(2, 3, 4))
 
 	multiVer1.And(multiVer2)
-	assert.Equal(t, *roaring.BitmapOf(2, 3, 4), *(multiVer1.versions[int64(12)]))
+	assert.Equal(t, *roaring.BitmapOf(2, 3, 4), *(multiVer1.versions[uint32(12)]))
 
 	multiVer3 := NewMultiVerSeriesIDSet()
-	multiVer3.Add(int64(13), roaring.BitmapOf(2, 3, 4))
+	multiVer3.Add(uint32(13), roaring.BitmapOf(2, 3, 4))
 	multiVer1.And(multiVer3)
 	assert.Equal(t, 0, len(multiVer1.versions))
 }
 
 func TestMultiVerSeriesIDSet_Or(t *testing.T) {
 	multiVer1 := NewMultiVerSeriesIDSet()
-	multiVer1.Add(int64(12), roaring.BitmapOf(1, 4, 5))
-	assert.Equal(t, *roaring.BitmapOf(1, 4, 5), *(multiVer1.versions[int64(12)]))
+	multiVer1.Add(uint32(12), roaring.BitmapOf(1, 4, 5))
+	assert.Equal(t, *roaring.BitmapOf(1, 4, 5), *(multiVer1.versions[uint32(12)]))
 
 	multiVer2 := NewMultiVerSeriesIDSet()
-	multiVer2.Add(int64(12), roaring.BitmapOf(2, 3, 4))
+	multiVer2.Add(uint32(12), roaring.BitmapOf(2, 3, 4))
 
 	multiVer1.Or(multiVer2)
-	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4, 5), *(multiVer1.versions[int64(12)]))
+	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4, 5), *(multiVer1.versions[uint32(12)]))
 
 	multiVer3 := NewMultiVerSeriesIDSet()
-	multiVer3.Add(int64(13), roaring.BitmapOf(7, 8, 9))
+	multiVer3.Add(uint32(13), roaring.BitmapOf(7, 8, 9))
 	multiVer1.Or(multiVer3)
 	assert.Equal(t, 2, len(multiVer1.versions))
-	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4, 5), *(multiVer1.versions[int64(12)]))
-	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[int64(13)]))
+	assert.Equal(t, *roaring.BitmapOf(1, 2, 3, 4, 5), *(multiVer1.versions[uint32(12)]))
+	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[uint32(13)]))
 }
 
 func TestMultiVerSeriesIDSet_AndNot(t *testing.T) {
 	multiVer1 := NewMultiVerSeriesIDSet()
-	multiVer1.Add(int64(12), roaring.BitmapOf(1, 2, 4, 6, 7, 8, 9))
-	multiVer1.Add(int64(13), roaring.BitmapOf(7, 8, 9))
-	assert.Equal(t, *roaring.BitmapOf(1, 2, 4, 6, 7, 8, 9), *(multiVer1.versions[int64(12)]))
+	multiVer1.Add(uint32(12), roaring.BitmapOf(1, 2, 4, 6, 7, 8, 9))
+	multiVer1.Add(uint32(13), roaring.BitmapOf(7, 8, 9))
+	assert.Equal(t, *roaring.BitmapOf(1, 2, 4, 6, 7, 8, 9), *(multiVer1.versions[uint32(12)]))
 
 	multiVer2 := NewMultiVerSeriesIDSet()
-	multiVer2.Add(int64(12), roaring.BitmapOf(2, 3, 4, 9))
+	multiVer2.Add(uint32(12), roaring.BitmapOf(2, 3, 4, 9))
 
 	multiVer1.AndNot(multiVer2)
 	assert.Equal(t, 2, len(multiVer1.versions))
-	assert.Equal(t, *roaring.BitmapOf(1, 6, 7, 8), *(multiVer1.versions[int64(12)]))
-	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[int64(13)]))
+	assert.Equal(t, *roaring.BitmapOf(1, 6, 7, 8), *(multiVer1.versions[uint32(12)]))
+	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[uint32(13)]))
 
 	multiVer3 := NewMultiVerSeriesIDSet()
-	multiVer3.Add(int64(14), roaring.BitmapOf(7))
+	multiVer3.Add(uint32(14), roaring.BitmapOf(7))
 	multiVer1.AndNot(multiVer3)
 
 	assert.Equal(t, 2, len(multiVer1.versions))
-	assert.Equal(t, *roaring.BitmapOf(1, 6, 7, 8), *(multiVer1.versions[int64(12)]))
-	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[int64(13)]))
+	assert.Equal(t, *roaring.BitmapOf(1, 6, 7, 8), *(multiVer1.versions[uint32(12)]))
+	assert.Equal(t, *roaring.BitmapOf(7, 8, 9), *(multiVer1.versions[uint32(13)]))
 }


### PR DESCRIPTION
- support querying from index table, such as series.Filter( FindSeriesIDsByExpr and GetSeriesIDsForTag), this is the capacities of inverted index;
- deserialization free trie-tree range query by rank-select ;
- forward index of index will be implemented in next PR.
-  `regex-expression filter` of series.Filter and `series.MetaGetter` is related to  forward index, so those two functions are still in development;
- remove time-range of tStore,  timeRange will be ignored during filtering from memdb
- fix evicted tStore allocated different seriesID when generated again;