### PR TITLE
[feat][*]: colorize terminal output & adjust logger format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
         - vendor
         - bin
         - ci
+        - cmd
     # modules-download-mode: readonly
 
 

--- a/broker/api/login.go
+++ b/broker/api/login.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lindb/lindb/pkg/logger"
 )
 
-var log = logger.GetLogger("login")
+var log = logger.GetLogger("broker", "LoginAPI")
 
 // LoginAPI represents login param
 type LoginAPI struct {

--- a/broker/runtime.go
+++ b/broker/runtime.go
@@ -107,7 +107,7 @@ func NewBrokerRuntime(config config.Broker) server.Service {
 		config: config,
 		ctx:    ctx,
 		cancel: cancel,
-		log:    logger.GetLogger("broker/runtime"),
+		log:    logger.GetLogger("broker", "Runtime"),
 	}
 }
 

--- a/cmd/lind/env.go
+++ b/cmd/lind/env.go
@@ -10,13 +10,22 @@ import (
 // These variables are populated via the Go linker.
 var (
 	// release version, ldflags
-	version = "unknown"
+	version = ""
 	// binary build-time, ldflags
 	buildTime = "unknown"
 )
 
+const defaultVersion = "0.0.0"
+
+func getVersion() string {
+	if version == "" {
+		return defaultVersion
+	}
+	return version
+}
+
 func printVersion() {
-	fmt.Printf("LinDB %v, BuildDate: %v\n", version, buildTime)
+	fmt.Printf("LinDB: %v, BuildDate: %v\n", getVersion(), buildTime)
 }
 
 var versionCmd = &cobra.Command{

--- a/cmd/lind/root.go
+++ b/cmd/lind/root.go
@@ -2,20 +2,33 @@ package lind
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/lindb/lindb/pkg/logger"
 
 	"github.com/spf13/cobra"
 )
 
+const linDBLogo = `
+██╗     ██╗███╗   ██╗██████╗ ██████╗ 
+██║     ██║████╗  ██║██╔══██╗██╔══██╗
+██║     ██║██╔██╗ ██║██║  ██║██████╔╝
+██║     ██║██║╚██╗██║██║  ██║██╔══██╗
+███████╗██║██║ ╚████║██████╔╝██████╔╝
+╚══════╝╚═╝╚═╝  ╚═══╝╚═════╝ ╚═════╝ 
+`
+
+func printLogoWhenIsTty() {
+	if logger.IsTerminal(os.Stdout) {
+		fmt.Fprintf(os.Stdout, logger.Cyan.Add(linDBLogo))
+		fmt.Fprintf(os.Stdout, logger.Green.Add(" ::  LinDB  :: ")+
+			fmt.Sprintf("%22s", fmt.Sprintf("(v%s Release)", getVersion())))
+		fmt.Fprintf(os.Stdout, "\n\n")
+	}
+}
+
 const (
 	linDBText = `
-    __     _             ____     ____ 
-   / /    (_)   ____    / __ \   / __ )
-  / /    / /   / __ \  / / / /  / __  |
- / /___ / /   / / / / / /_/ /  / /_/ / 
-/_____//_/   /_/ /_/ /_____/  /_____/  
-
-version: %s, build time: %s
-
 LinDB is a scalable, high performance, high availability, distributed time series database.
 Complete documentation is available at https://lindb.io
 `
@@ -25,7 +38,7 @@ Complete documentation is available at https://lindb.io
 var RootCmd = &cobra.Command{
 	Use:   "lind",
 	Short: "lind is the main command, used to control LinDB",
-	Long:  fmt.Sprintf(linDBText, version, buildTime),
+	Long:  linDBLogo + linDBText,
 }
 
 func init() {

--- a/cmd/lind/runner.go
+++ b/cmd/lind/runner.go
@@ -9,6 +9,7 @@ import (
 
 // serveStandalone runs the cluster as standalone mode
 func run(ctx context.Context, service server.Service) error {
+	printLogoWhenIsTty()
 	// start service
 	if err := service.Run(); err != nil {
 		return fmt.Errorf("run service[%s] error:%s", service.Name(), err)

--- a/coordinator/broker.go
+++ b/coordinator/broker.go
@@ -21,7 +21,7 @@ type BrokerStateMachines struct {
 func NewBrokerStateMachines(factory StateMachineFactory) *BrokerStateMachines {
 	return &BrokerStateMachines{
 		factory: factory,
-		log:     logger.GetLogger("coordinator/broker/sm"),
+		log:     logger.GetLogger("coordinator", "BrokerFSM"),
 	}
 }
 

--- a/coordinator/broker/node_state_machine.go
+++ b/coordinator/broker/node_state_machine.go
@@ -51,7 +51,7 @@ func NewNodeStateMachine(ctx context.Context, currentNode models.Node, discovery
 		cancel:      cancel,
 		currentNode: currentNode,
 		nodes:       make(map[string]models.ActiveNode),
-		log:         logger.GetLogger("broker/node/sm"),
+		log:         logger.GetLogger("broker", "NodeFSM"),
 	}
 	// new replica status discovery
 	stateMachine.discovery = discoveryFactory.CreateDiscovery(constants.ActiveNodesPath, stateMachine)

--- a/coordinator/broker/storage_cluster.go
+++ b/coordinator/broker/storage_cluster.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lindb/lindb/rpc"
 )
 
-var log = logger.GetLogger("broker/storage/state")
+var log = logger.GetLogger("broker", "StorageState")
 
 const dummy = ""
 

--- a/coordinator/broker/storage_state_machine.go
+++ b/coordinator/broker/storage_state_machine.go
@@ -16,6 +16,10 @@ import (
 
 //go:generate mockgen -source=./storage_state_machine.go -destination=./storage_state_machine_mock.go -package=broker
 
+var (
+	storageFSMLogger = logger.GetLogger("broker", "StorageFSM")
+)
+
 // StorageStateMachine represents storage cluster state state machine.
 // Each broker node will start this state machine which watch storage cluster state change event.
 type StorageStateMachine interface {
@@ -44,7 +48,7 @@ type storageStateMachine struct {
 func NewStorageStateMachine(ctx context.Context,
 	discoveryFactory discovery.Factory, taskClientFactory rpc.TaskClientFactory) (StorageStateMachine, error) {
 	c, cancel := context.WithCancel(ctx)
-	log := logger.GetLogger("broker/storage/state/machine")
+	log := storageFSMLogger
 	stateMachine := &storageStateMachine{
 		taskClientFactory: taskClientFactory,
 		ctx:               c,

--- a/coordinator/context/master.go
+++ b/coordinator/context/master.go
@@ -26,7 +26,7 @@ func NewMasterContext(stateMachine *StateMachine) *MasterContext {
 
 // Close closes all state machines, releases resource that master used
 func (m *MasterContext) Close() {
-	log := logger.GetLogger("coordinator/context")
+	log := logger.GetLogger("coordinator", "context")
 	if m.stateMachine.StorageCluster != nil {
 		if err := m.stateMachine.StorageCluster.Close(); err != nil {
 			log.Error("close storage cluster state machine error", logger.Error(err), logger.Stack())

--- a/coordinator/database/admin_state_machine.go
+++ b/coordinator/database/admin_state_machine.go
@@ -48,7 +48,7 @@ func NewAdminStateMachine(ctx context.Context, discoveryFactory discovery.Factor
 		storageCluster: storageCluster,
 		ctx:            c,
 		cancel:         cancel,
-		log:            logger.GetLogger("database/admin/state/machine"),
+		log:            logger.GetLogger("coordinator", "AdminStateMachine"),
 	}
 	// new database config discovery
 	stateMachine.discovery = discoveryFactory.CreateDiscovery(constants.DatabaseConfigPath, stateMachine)

--- a/coordinator/discovery/discovery.go
+++ b/coordinator/discovery/discovery.go
@@ -42,7 +42,7 @@ func (f *factory) CreateDiscovery(prefix string, listener Listener) Discovery {
 		ctx:      ctx,
 		cancel:   cancel,
 		listener: listener,
-		log:      logger.GetLogger("coordinator/discovery"),
+		log:      logger.GetLogger("coordinator", "DiscoveryFactory"),
 	}
 }
 

--- a/coordinator/discovery/registry.go
+++ b/coordinator/discovery/registry.go
@@ -43,7 +43,7 @@ func NewRegistry(repo state.Repository, prefix string, ttl int64) Registry {
 		repo:   repo,
 		ctx:    ctx,
 		cancel: cancel,
-		log:    logger.GetLogger("coordinator/registry"),
+		log:    logger.GetLogger("coordinator", "Registry"),
 	}
 }
 

--- a/coordinator/elect/election.go
+++ b/coordinator/elect/election.go
@@ -16,7 +16,7 @@ import (
 
 //go:generate mockgen -source=./election.go -destination=./election_mock.go -package=elect
 
-var log = logger.GetLogger("coordinator/elect")
+var log = logger.GetLogger("coordinator", "Election")
 
 // Listener represent master change callback interface
 type Listener interface {

--- a/coordinator/master.go
+++ b/coordinator/master.go
@@ -19,7 +19,7 @@ import (
 
 //go:generate mockgen -source=./master.go -destination=./master_mock.go -package=coordinator
 
-var log = logger.GetLogger("coordinator/master")
+var log = logger.GetLogger("coordinator", "Master")
 
 // MasterCfg represents the config for master creating
 type MasterCfg struct {

--- a/coordinator/replica/replicator_state_machine.go
+++ b/coordinator/replica/replicator_state_machine.go
@@ -55,7 +55,7 @@ func NewReplicatorStateMachine(ctx context.Context,
 		cancel:       cancel,
 		cm:           cm,
 		shardAssigns: make(map[string]*models.ShardAssignment),
-		log:          logger.GetLogger("coordinator/replicator/sm"),
+		log:          logger.GetLogger("coordinator", "ReplicatorFSM"),
 	}
 	for _, shardAssign := range shardAssigns {
 		stateMachine.buildShardAssign(shardAssign)

--- a/coordinator/replica/status_state_machine.go
+++ b/coordinator/replica/status_state_machine.go
@@ -52,7 +52,7 @@ func NewStatusStateMachine(ctx context.Context, factory discovery.Factory) (Stat
 		ctx:     c,
 		cancel:  cancel,
 		brokers: make(map[string]models.BrokerReplicaState),
-		log:     logger.GetLogger("replica/status/state/machine"),
+		log:     logger.GetLogger("coordinator", "ReplicaFSM"),
 	}
 	repo := factory.GetRepo()
 	replicaStatusList, err := repo.List(c, constants.ReplicaStatePath)

--- a/coordinator/storage/cluster.go
+++ b/coordinator/storage/cluster.go
@@ -19,7 +19,7 @@ import (
 
 //go:generate mockgen -source=./cluster.go -destination=./cluster_mock.go -package=storage
 
-var log = logger.GetLogger("coordinator/storage/cluster")
+var log = logger.GetLogger("coordinator", "StorageCluster")
 
 // clusterCfg represents the config which creates cluster instance need
 // IMPORTANT: need clean config's resource

--- a/coordinator/storage/cluster_state_machine.go
+++ b/coordinator/storage/cluster_state_machine.go
@@ -61,7 +61,7 @@ func NewClusterStateMachine(
 	repoFactory state.RepositoryFactory,
 	storageStateService service.StorageStateService,
 	shardAssignService service.ShardAssignService) (ClusterStateMachine, error) {
-	log := logger.GetLogger("cluster/state/machine")
+	log := logger.GetLogger("coordinator", "ClusterFSM")
 	c, cancel := context.WithCancel(ctx)
 	stateMachine := &clusterStateMachine{
 		repo:                repo,

--- a/coordinator/storage/create_shard_task.go
+++ b/coordinator/storage/create_shard_task.go
@@ -36,7 +36,7 @@ func (p *createShardProcessor) Process(ctx context.Context, task task.Task) erro
 	if err := encoding.JSONUnmarshal(task.Params, &param); err != nil {
 		return err
 	}
-	logger.GetLogger("create_shard/task").
+	logger.GetLogger("coordinator", "createShardProcessor").
 		Info("process create shard task", logger.String("params", string(task.Params)))
 	if err := p.storageService.CreateShards(param.Database, param.Engine, param.ShardIDs...); err != nil {
 		return err

--- a/coordinator/storage/task_executor.go
+++ b/coordinator/storage/task_executor.go
@@ -35,7 +35,7 @@ func NewTaskExecutor(ctx context.Context,
 		repo:           repo,
 		executor:       executor,
 		storageService: storageService,
-		log:            logger.GetLogger("storage/task/executor"),
+		log:            logger.GetLogger("storage", "TaskExecutor"),
 	}
 }
 

--- a/coordinator/task/controller.go
+++ b/coordinator/task/controller.go
@@ -20,7 +20,7 @@ var (
 	ErrMaxTasksLimitExceeded = fmt.Errorf("coordinator/task: tasks number can not greater than %d", maxTasksLimit)
 )
 
-var log = logger.GetLogger("coordinator/task")
+var log = logger.GetLogger("coordinator", "TaskController")
 
 // ControllerFactory represents a task controller create factory
 type ControllerFactory interface {

--- a/coordinator/task/executor.go
+++ b/coordinator/task/executor.go
@@ -33,7 +33,7 @@ func NewExecutor(ctx context.Context, node *models.Node, repo state.Repository) 
 		processors: map[Kind]*taskProcessor{},
 		ctx:        ctx,
 		cancel:     cancel,
-		log:        logger.GetLogger("coordinator/task/executor"),
+		log:        logger.GetLogger("coordinator", "TaskExecutor"),
 	}
 }
 

--- a/coordinator/task/processor.go
+++ b/coordinator/task/processor.go
@@ -94,7 +94,7 @@ func (p *taskProcessor) run() {
 }
 
 func (p *taskProcessor) process(evt taskEvent) {
-	log := logger.GetLogger("coordinator/task/processor")
+	log := logger.GetLogger("coordinator", "TaskProcessor")
 	defer func() {
 		// wait task process done
 		p.wg.Done()

--- a/kv/family.go
+++ b/kv/family.go
@@ -35,7 +35,7 @@ func newFamily(store *store, option FamilyOption) (Family, error) {
 	name := option.Name
 
 	familyPath := filepath.Join(store.option.Path, name)
-	log := logger.GetLogger(fmt.Sprintf("kv/family[%s]", familyPath))
+	log := logger.GetLogger("kv", fmt.Sprintf("Family[%s]", familyPath))
 
 	if !fileutil.Exist(familyPath) {
 		if err := fileutil.MkDir(familyPath); err != nil {

--- a/kv/store.go
+++ b/kv/store.go
@@ -67,7 +67,7 @@ func NewStore(name string, option StoreOption) (Store, error) {
 		return nil, err
 	}
 
-	log := logger.GetLogger(fmt.Sprintf("kv/store[%s]", option.Path))
+	log := logger.GetLogger("kv", fmt.Sprintf("Store[%s]", option.Path))
 
 	// unlock file lock if error
 	defer func() {

--- a/kv/table/builder.go
+++ b/kv/table/builder.go
@@ -62,7 +62,7 @@ type storeBuilder struct {
 func NewStoreBuilder(path string, fileNumber int64) (Builder, error) {
 	fileName := filepath.Join(path, version.Table(fileNumber))
 	keys := roaring.New()
-	log := logger.GetLogger(fmt.Sprintf("kv/builder[%s]", fileName))
+	log := logger.GetLogger("kv", fmt.Sprintf("Builder[%s]", fileName))
 	writer, err := bufioutil.NewBufioWriter(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("create file write for store builder error:%s", err)

--- a/kv/table/cache.go
+++ b/kv/table/cache.go
@@ -33,7 +33,7 @@ func NewCache(storePath string) Cache {
 	return &mapCache{
 		storePath: storePath,
 		readers:   make(map[string]Reader),
-		log:       logger.GetLogger(fmt.Sprintf("kv/cache[%s]", storePath)),
+		log:       logger.GetLogger("kv", fmt.Sprintf("Cache[%s]", storePath)),
 	}
 }
 

--- a/kv/version/edit_log.go
+++ b/kv/version/edit_log.go
@@ -16,12 +16,14 @@ const StoreFamilyID = 0
 type EditLog struct {
 	logs     []Log
 	familyID int
+	logger   *logger.Logger
 }
 
 // NewEditLog new EditLog instance
 func NewEditLog(familyID int) *EditLog {
 	return &EditLog{
 		familyID: familyID,
+		logger:   logger.GetLogger("kv", "EditLog"),
 	}
 }
 
@@ -94,13 +96,12 @@ func (el *EditLog) apply(version *Version) {
 
 // apply store edit logs into version set
 func (el *EditLog) applyVersionSet(versionSet *StoreVersionSet) {
-	l := logger.GetLogger("kv/edit/log")
 	for _, log := range el.logs {
 		switch v := log.(type) {
 		case StoreLog:
 			v.applyVersionSet(versionSet)
 		default:
-			l.Warn("cannot apply family edit log to version set")
+			el.logger.Warn("cannot apply family edit log to version set")
 		}
 	}
 }

--- a/kv/version/version_set.go
+++ b/kv/version/version_set.go
@@ -39,7 +39,7 @@ func NewStoreVersionSet(storePath string, numOfLevels int) *StoreVersionSet {
 		numOfLevels:        numOfLevels,
 		familyVersions:     make(map[string]*FamilyVersion),
 		familyIDs:          make(map[int]string),
-		logger:             logger.GetLogger(fmt.Sprintf("kv/version/set[%s]", storePath)),
+		logger:             logger.GetLogger("kv", fmt.Sprintf("VersionSet[%s]", storePath)),
 	}
 }
 

--- a/parallel/task_handler.go
+++ b/parallel/task_handler.go
@@ -21,7 +21,7 @@ func NewTaskHandler(fct rpc.TaskServerFactory, dispatcher TaskDispatcher) *TaskH
 	return &TaskHandler{
 		fct:        fct,
 		dispatcher: dispatcher,
-		logger:     logger.GetLogger("parallel/task/handler"),
+		logger:     logger.GetLogger("parallel", "TaskHandler"),
 	}
 }
 

--- a/pkg/encoding/json.go
+++ b/pkg/encoding/json.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lindb/lindb/pkg/logger"
 )
 
-var log = logger.GetLogger("encoding")
+var log = logger.GetLogger("pkg/encoding", "JSONMarshaller")
 
 // JSONMarshal returns the JSON encoding of v.
 func JSONMarshal(v interface{}) []byte {

--- a/pkg/fileutil/mmap.go
+++ b/pkg/fileutil/mmap.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lindb/lindb/pkg/logger"
 )
 
-var log = logger.GetLogger("pkg/mmap")
+var log = logger.GetLogger("pkg/fileutil", "MMAP")
 
 const (
 	read = 1 << iota

--- a/pkg/lockers/file_lock.go
+++ b/pkg/lockers/file_lock.go
@@ -19,7 +19,7 @@ type FileLock struct {
 func NewFileLock(fileName string) *FileLock {
 	return &FileLock{
 		fileName: fileName,
-		logger:   logger.GetLogger(fmt.Sprintf("file/lock[%s]", fileName)),
+		logger:   logger.GetLogger("pkg/lockers", fmt.Sprintf("FileLock[%s]", fileName)),
 	}
 }
 

--- a/pkg/logger/color.go
+++ b/pkg/logger/color.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"fmt"
+)
+
+// Foreground colors.
+const (
+	Black Color = iota + 30
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+)
+
+// Color represents a text color.
+type Color uint8
+
+// Add adds the coloring to the given string.
+func (c Color) Add(s string) string {
+	return fmt.Sprintf("\x1b[%dm%s\x1b[0m", uint8(c), s)
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_Logger(t *testing.T) {
-	logger1 := GetLogger("test")
+	logger1 := GetLogger("pkg/logger", "test")
 	logger1.Warn("warn for test", String("count", "1"), Reflect("v1", map[string]string{"a": "1"}))
 	logger1.Info("info for test", Uint16("value", 1), Int32("v1", 2),
 		Int64("v2", 2), Any("v3", 3))
@@ -19,13 +19,16 @@ func Test_Logger(t *testing.T) {
 
 	logger2 := New()
 	assert.NotNil(t, logger2)
+
+	logger3 := GetLogger("pkg/logger", "")
+	logger3.Error("error test")
 }
 
 func Test_Logger_Stack(t *testing.T) {
 	panicFunc := func() {
 		defer func() {
 			if r := recover(); r != nil {
-				GetLogger("test-panic").log.Panic("panic stack", Stack())
+				GetLogger("pkg/logger", "test-panic").log.Panic("panic stack", Stack())
 			}
 		}()
 		panic("test-panic")

--- a/pkg/queue/fanout.go
+++ b/pkg/queue/fanout.go
@@ -286,7 +286,7 @@ func NewFanOut(metaPath string, q FanOutQueue) (FanOut, error) {
 		seg:     seg,
 		headSeq: headSeq,
 		tailSeq: tailSeq,
-		logger:  logger.GetLogger("pkg/fanout"),
+		logger:  logger.GetLogger("pkg/queue", "FanOut"),
 	}, nil
 }
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -104,7 +104,7 @@ func NewQueue(dirPath string, dataFileSizeLimit int, removeTaskInterval time.Dur
 		headSeq:           headSeq,
 		tailSeq:           tailSeq,
 		rmSegmentsTicker:  time.NewTicker(removeTaskInterval),
-		logger:            logger.GetLogger("pkg/queue"),
+		logger:            logger.GetLogger("pkg/queue", "Queue"),
 	}
 
 	q.initRemoveSegmentsTask()

--- a/pkg/queue/segment/factory.go
+++ b/pkg/queue/segment/factory.go
@@ -107,7 +107,7 @@ func NewFactory(dirPath string, dataFileSizeLimit int, headSeq, tailSeq int64) (
 		dataFileSizeLimit: dataFileSizeLimit,
 		segments:          make([]Segment, 0),
 		seqRange:          make(SeqRange, 0),
-		logger:            logger.GetLogger("pkg/factory"),
+		logger:            logger.GetLogger("pkg/queue", "SegmentFactory"),
 	}
 
 	// load from file

--- a/pkg/queue/segment/segment.go
+++ b/pkg/queue/segment/segment.go
@@ -67,7 +67,7 @@ func NewSegment(indexPage, dataPage page.MappedPage, begin, end int64) (Segment,
 		dataPage:  dataPage,
 		begin:     begin,
 		end:       end,
-		logger:    logger.GetLogger("pkg/segment"),
+		logger:    logger.GetLogger("pkg/queue", "Segment"),
 	}
 
 	if err := seg.adjustOffset(); err != nil {

--- a/pkg/state/etcd.go
+++ b/pkg/state/etcd.go
@@ -27,7 +27,8 @@ func newEtedRepository(config Config) (Repository, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create etc client error:%s", err)
 	}
-	logger.GetLogger("state").Info("new etcd client successfully", logger.Any("endpoints", config.Endpoints))
+	logger.GetLogger("pkg/state", "ETCDRepository").Info("new etcd client successfully",
+		logger.Any("endpoints", config.Endpoints))
 	return &etcdRepository{
 		namespace: config.Namespace,
 		client:    cli,

--- a/pkg/state/heartbeat.go
+++ b/pkg/state/heartbeat.go
@@ -67,7 +67,7 @@ func (h *heartbeat) grantKeepAliveLease(ctx context.Context) (bool, error) {
 
 // keepAlive does keepalive and retry,if the key should be not exist,it should retry
 func (h *heartbeat) keepAlive(ctx context.Context) {
-	log := logger.GetLogger("state/heartbeat")
+	log := logger.GetLogger("pkg/state", "HeartBeat")
 	var (
 		err error
 		gap = 100 * time.Millisecond

--- a/pkg/util/host.go
+++ b/pkg/util/host.go
@@ -75,7 +75,7 @@ func GetHostIP() (string, error) {
 func GetHostName() string {
 	hostName, err := osHostname()
 	if err != nil {
-		logger.GetLogger("host").Warn("get host name", logger.Error(err))
+		logger.GetLogger("pkg/util", "HostGetter").Warn("get host name", logger.Error(err))
 		hostName = "unknown"
 	}
 	return hostName

--- a/replication/channel.go
+++ b/replication/channel.go
@@ -25,7 +25,7 @@ var ErrCanceled = errors.New("write data ctx done")
 
 const defaultReportInterval = 30
 
-var log = logger.GetLogger("replication")
+var log = logger.GetLogger("replication", "ChannelManager")
 
 // ChannelManager manages the construction, retrieving, closing for all channels.
 type ChannelManager interface {
@@ -262,7 +262,7 @@ func newChannel(cxt context.Context, cfg config.ReplicationChannel, database str
 		shardID:  shardID,
 		q:        q,
 		ch:       make(chan []byte, cfg.BufferSize),
-		logger:   logger.GetLogger("replication/channel"),
+		logger:   logger.GetLogger("replication", "Channel"),
 	}
 
 	c.initAppendTask()

--- a/replication/replicator.go
+++ b/replication/replicator.go
@@ -70,7 +70,7 @@ func newReplicator(target models.Node, database string, shardID int32,
 		shardID:  shardID,
 		fo:       fo,
 		fct:      fct,
-		logger:   logger.GetLogger("replication/replicator"),
+		logger:   logger.GetLogger("replication", "Replicator"),
 	}
 
 	go r.recvLoop()

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -31,7 +31,7 @@ func NewTCPServer(bindAddress string) TCPServer {
 	return &server{
 		bindAddress: bindAddress,
 		gs:          grpc.NewServer(),
-		logger:      logger.GetLogger("rpc/server"),
+		logger:      logger.GetLogger("rpc", "Server"),
 	}
 }
 

--- a/rpc/task_transport.go
+++ b/rpc/task_transport.go
@@ -12,7 +12,7 @@ import (
 
 //go:generate mockgen -source ./task_transport.go -destination=./task_transport_mock.go -package=rpc
 
-var log = logger.GetLogger("rpc/task")
+var log = logger.GetLogger("rpc", "TaskClient")
 
 // TaskClientFactory represents the task stream manage
 type TaskClientFactory interface {

--- a/service/database.go
+++ b/service/database.go
@@ -87,7 +87,7 @@ func (db *databaseService) List() ([]*models.Database, error) {
 		db := &models.Database{}
 		err = json.Unmarshal(val.Value, db)
 		if err != nil {
-			logger.GetLogger("service/db").
+			logger.GetLogger("service", "DatabaseService").
 				Warn("unmarshal data error",
 					logger.String("data", string(val.Value)))
 		} else {

--- a/service/shard_assign.go
+++ b/service/shard_assign.go
@@ -50,7 +50,7 @@ func (s *shardAssignService) List() ([]*models.ShardAssignment, error) {
 		shardAssign := &models.ShardAssignment{}
 		err = encoding.JSONUnmarshal(val.Value, shardAssign)
 		if err != nil {
-			logger.GetLogger("service/shard/assign").
+			logger.GetLogger("service", "ShardAssignService").
 				Warn("unmarshal data error",
 					logger.String("data", string(val.Value)))
 		} else {

--- a/service/storage_cluster.go
+++ b/service/storage_cluster.go
@@ -91,7 +91,7 @@ func (s *storageClusterService) List() ([]*models.StorageCluster, error) {
 		storageCluster := &models.StorageCluster{}
 		err = json.Unmarshal(val.Value, storageCluster)
 		if err != nil {
-			logger.GetLogger("service/storage/cluster").
+			logger.GetLogger("service", "StorageCluster").
 				Warn("unmarshal data error",
 					logger.String("data", string(val.Value)))
 		} else {

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lindb/lindb/sql/stmt"
 )
 
-var log = logger.GetLogger("sql/parser")
+var log = logger.GetLogger("sql", "Parser")
 var errorHandle = &errorListener{}
 var walker = antlr.ParseTreeWalkerDefault
 

--- a/standalone/runtime.go
+++ b/standalone/runtime.go
@@ -18,7 +18,7 @@ import (
 	"github.com/lindb/lindb/storage"
 )
 
-var log = logger.GetLogger("standalone")
+var log = logger.GetLogger("standalone", "Runtime")
 
 // runtime represents the runtime dependency of standalone mode
 type runtime struct {

--- a/storage/handler/writer.go
+++ b/storage/handler/writer.go
@@ -27,7 +27,7 @@ func NewWriter(storageService service.StorageService, sm replication.SequenceMan
 	return &Writer{
 		storageService: storageService,
 		sm:             sm,
-		logger:         logger.GetLogger("handler/writer"),
+		logger:         logger.GetLogger("storage", "Writer"),
 	}
 }
 

--- a/storage/runtime.go
+++ b/storage/runtime.go
@@ -70,7 +70,7 @@ func NewStorageRuntime(config config.Storage) server.Service {
 		ctx:    ctx,
 		cancel: cancel,
 
-		log: logger.GetLogger("storage/runtime"),
+		log: logger.GetLogger("storage", "Runtime"),
 	}
 }
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -17,7 +17,7 @@ import (
 const options = "OPTIONS"
 const shardPath = "shard"
 
-var log = logger.GetLogger("engine")
+var log = logger.GetLogger("tsdb", "Engine")
 
 // EngineFactory represents a time series engine create factory
 type EngineFactory interface {

--- a/tsdb/indextbl/metrics_flusher.go
+++ b/tsdb/indextbl/metrics_flusher.go
@@ -15,7 +15,7 @@ import (
 //go:generate mockgen -source ./metrics_flusher.go -destination=./metrics_flusher_mock.go -package indextbl
 
 var (
-	moduleLogger = logger.GetLogger("tsdb/indextbl")
+	nameIDIndexFlusherLogger = logger.GetLogger("tsdb", "IndexTableFlusher")
 )
 
 // MetricsNameIDFlusher is a wrapper of kv.Builder, provides the ability to store metricNames and metricIDs to disk.
@@ -86,7 +86,7 @@ func (f *metricsMetaFlusher) FlushTagKeyID(tagKey string, tagID uint32) {
 		return
 	}
 	if len(tagKey) > math.MaxUint8 {
-		moduleLogger.Error("tagKey too long", zap.Int("length", len(tagKey)))
+		nameIDIndexFlusherLogger.Error("tagKey too long", zap.Int("length", len(tagKey)))
 	}
 	// write tagKey
 	f.tagsBuf.WriteByte(byte(len(tagKey)))
@@ -102,7 +102,7 @@ func (f *metricsMetaFlusher) FlushFieldID(fieldName string, fieldType field.Type
 		return
 	}
 	if len(fieldName) > math.MaxUint8 {
-		moduleLogger.Error("fieldName too long", zap.Int("length", len(fieldName)))
+		nameIDIndexFlusherLogger.Error("fieldName too long", zap.Int("length", len(fieldName)))
 	}
 	// write field-name
 	f.fieldBuf.WriteByte(byte(len(fieldName)))

--- a/tsdb/indextbl/series_flusher.go
+++ b/tsdb/indextbl/series_flusher.go
@@ -15,6 +15,8 @@ import (
 
 //go:generate mockgen -source ./series_flusher.go -destination=./series_flusher_mock.go -package indextbl
 
+var seriesIndexFlusherLogger = logger.GetLogger("tsdb", "SeriesIndexTableFlusher")
+
 // SeriesIndexFlusher is a wrapper of kv.Builder, provides the ability to build a versioned series-id index table.
 // The layout is available in `tsdb/doc.go`
 type SeriesIndexFlusher interface {
@@ -86,7 +88,7 @@ func (w *seriesIndexFlusher) FlushVersion(version uint32, startTime, endTime uin
 	// write bitmap length
 	out, err := bitmap.MarshalBinary()
 	if err != nil {
-		moduleLogger.Error("marshal bitmap failure", logger.Error(err))
+		seriesIndexFlusherLogger.Error("marshal bitmap failure", logger.Error(err))
 	}
 	size = binary.PutUvarint(w.VariableBuf[:], uint64(len(out)))
 	_, _ = w.tagValueBuffer.Write(w.VariableBuf[:size])

--- a/tsdb/indextbl/series_reader.go
+++ b/tsdb/indextbl/series_reader.go
@@ -15,6 +15,8 @@ import (
 	"github.com/lindb/lindb/tsdb/series"
 )
 
+var seriesIndexReaderLogger = logger.GetLogger("tsdb", "SeriesIndexTableReader")
+
 //go:generate mockgen -source ./series_reader.go -destination=./series_reader_mock.go -package indextbl
 
 const (
@@ -61,7 +63,7 @@ func (r *seriesIndexReader) FindSeriesIDsByExprForTagID(tagID uint32, expr stmt.
 		var offsets []int
 		q, err := r.entrySetBlockToTreeQuerier(entrySetBlock)
 		if err != nil {
-			moduleLogger.Error("failed reading trie-tree block", logger.Error(err))
+			seriesIndexReaderLogger.Error("failed reading trie-tree block", logger.Error(err))
 			continue
 		}
 		switch expression := expr.(type) {

--- a/tsdb/memdb/database.go
+++ b/tsdb/memdb/database.go
@@ -20,7 +20,7 @@ import (
 	"github.com/segmentio/fasthash/fnv1a"
 )
 
-var memDBLogger = logger.GetLogger("memdb")
+var memDBLogger = logger.GetLogger("tsdb", "MemDB")
 
 //go:generate mockgen -source ./database.go -destination=./database_mock.go -package memdb
 

--- a/tsdb/segment.go
+++ b/tsdb/segment.go
@@ -170,7 +170,7 @@ func newSegment(segmentName string, intervalType interval.Type, path string) (Se
 		baseTime:     baseTime,
 		kvStore:      kvStore,
 		intervalType: intervalType,
-		logger:       logger.GetLogger("tsdb/segment"),
+		logger:       logger.GetLogger("tsdb", "Segment"),
 	}, nil
 }
 


### PR DESCRIPTION
- print logo and version when is terminal 
- add color for log-level and module-name
- split log format to 5 parts: time, log-level, module-name, logger-role, log-message

![20190823112447](https://user-images.githubusercontent.com/21290558/63564685-a7a7be80-c598-11e9-83bc-61169883a516.jpg)
