### PR TITLE
[feat:#191][tsdb]: add suggest metrics

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -11,9 +11,6 @@ var (
 type Logging struct {
 	// Dir is the output directory for log-files
 	Dir string `toml:"dir"`
-	// logfmt, and json are available
-	// logfmt is more user-friendly, but json is more machine-readable
-	Format string `toml:"format"`
 	// Determine which level of logs will be emitted.
 	// error, warn, info, and debug are available
 	Level string `toml:"level"`
@@ -36,7 +33,6 @@ type Logging struct {
 func NewDefaultLoggingCfg() Logging {
 	return Logging{
 		Dir:        filepath.Join(defaultParentDir, "log"),
-		Format:     "logfmt",
 		Level:      "info",
 		MaxSize:    500,
 		MaxBackups: 3,

--- a/constants/tsdb.go
+++ b/constants/tsdb.go
@@ -7,4 +7,6 @@ const (
 	MStoreMaxTagKeysCount = 512
 	// max fields limitation of a tsStore.
 	TStoreMaxFieldsCount = 1024
+	// the max number of suggestions count
+	MaxSuggestions = 10000
 )

--- a/pkg/field/iterator.go
+++ b/pkg/field/iterator.go
@@ -21,7 +21,7 @@ type GroupedTimeSeries interface {
 type MultiTimeSeries interface {
 	TimeSeries
 	// Version returns the version no.
-	Version() int64
+	Version() uint32
 	// ID returns the time series id under current metric
 	ID() uint32
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -58,14 +58,9 @@ func Test_InitLogger(t *testing.T) {
 	assert.NotNil(t, thisLogger.getInitializedOrDefaultLogger())
 	assert.NotNil(t, thisLogger.getInitializedOrDefaultLogger())
 
-	cfg3 := config.Logging{Level: "info", Format: "json"}
+	cfg3 := config.Logging{Level: "info"}
 	assert.Nil(t, InitLogger(cfg3))
-	GetLogger("test", "test").Info("hello world")
 
-	cfg4 := config.Logging{Level: "info", Format: "logfmt"}
+	cfg4 := config.Logging{Level: "debug"}
 	assert.Nil(t, InitLogger(cfg4))
-
-	cfg5 := config.Logging{Level: "debug", Format: "unknown"}
-	assert.NotNil(t, InitLogger(cfg5))
-
 }

--- a/pkg/logger/setting.go
+++ b/pkg/logger/setting.go
@@ -1,10 +1,8 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 
 	"github.com/lindb/lindb/config"
@@ -26,7 +24,7 @@ var (
 )
 
 const (
-	lindLogFile = "lind.log"
+	lindLogFilename = "lind.log"
 )
 
 // GetLogger return logger with module name
@@ -62,7 +60,7 @@ func newDefaultLogger() *zap.Logger {
 // InitLogger initializes a zap logger from user config
 func InitLogger(cfg config.Logging) error {
 	w := zapcore.AddSync(&lumberjack.Logger{
-		Filename:   filepath.Join(cfg.Dir, lindLogFile),
+		Filename:   filepath.Join(cfg.Dir, lindLogFilename),
 		MaxSize:    int(cfg.MaxSize),
 		MaxBackups: int(cfg.MaxBackups),
 		MaxAge:     int(cfg.MaxAge),
@@ -79,17 +77,8 @@ func InitLogger(cfg config.Logging) error {
 	encoderConfig.EncodeTime = SimpleTimeEncoder
 	encoderConfig.EncodeLevel = SimpleLevelEncoder
 	// check format
-	var encoder zapcore.Encoder
-	switch strings.ToLower(cfg.Format) {
-	case "json":
-		encoder = zapcore.NewJSONEncoder(encoderConfig)
-	case "logfmt":
-		encoder = zapcore.NewConsoleEncoder(encoderConfig)
-	default:
-		return fmt.Errorf("config format: %s is not supported", cfg.Format)
-	}
 	core := zapcore.NewCore(
-		encoder,
+		zapcore.NewConsoleEncoder(encoderConfig),
 		w,
 		RunningAtomicLevel)
 	logger.Store(zap.New(core))

--- a/tsdb/doc.go
+++ b/tsdb/doc.go
@@ -30,8 +30,8 @@ Shard  |               Shard |
 |                                     |              +--------------+                      |
 +------+----------------------+-------+              |              |                      |
        |                      |                      |              |                      |
-       | Flush                | Flush                | Flush        |                      | Flush
-       | NameIDIndex          | MetaIndex            | SeriesIndex  |                      | Metrics
+       |                      |                      | SeriesIndex- | ForwardIndex-        |
+       | NameIDIndexFlusher   | MetaIndexFlusher     | Flusher      | Flusher              | MetricDataFlusher
 +------v-------+       +------v-------+       +------v-------+------v-------+       +------v-------+
 | MetricNameID |       |  MetricMeta  |       |SeriesInverted| SeriesForward|       |  MetricData  |
 |  IndexTable  |       |  IndexTable  |       |  IndexTable  |  IndexTable  |       |    Table     |
@@ -41,10 +41,10 @@ Shard  |               Shard |
 b) Query flow
 
 Shard                  Shard
-+------+-------+       +-----+--------+
-|   Memory     |       |   Memory     <--------------+ series.MetaGetter
-|  Database    |       |  Database    |              | series.Filter
-+-----^-+------+       +-----^-+------+              | series.DataGetter
++------+-------+       +-----+--------+                Suggester
+|   Memory     |       |   Memory     <--------------+ MetaGetter
+|  Database    |       |  Database    |              | Filter
++-----^-+------+       +-----^-+------+              | DataGetter
       | |                    | |                     +----------------------
       | |                    | |
       | |           IDGetter | |
@@ -54,8 +54,8 @@ Shard                  Shard
 |                                     <--------------+--------------+                      |
 +------^----------------------^-------+              |              |                      |
        |                      |                      |              |                      |
-       ^ Read                 ^ Read                 ^              ^                      ^
-       | NameIDIndex          | MetaIndex            |series.Filter |series.MetaGetter     | series.DataGetter
+       ^ Suggester            ^ Suggester            ^ Suggester    ^                      ^
+       | NameIDIndexReader    | MetaIndexReader      | Filter       | MetaGetter           | DataGetter
 +------+-------+       +------+-------+       +------+-------+------+-------+       +------+-------+
 | MetricNameID |       |  MetricMeta  |       |SeriesInverted| SeriesForward|       |  MetricData  |
 |  IndexTable  |       |  IndexTable  |       |  IndexTable  |  IndexTable  |       |    Table     |

--- a/tsdb/indexdb/interface.go
+++ b/tsdb/indexdb/interface.go
@@ -39,6 +39,7 @@ type IndexDatabase interface {
 	IDGetter
 	series.MetaGetter
 	series.Filter
+	series.Suggester
 	// FlushNameIDsTo flushes metricName and metricID to flusher
 	FlushNameIDsTo(flusher tblstore.MetricsNameIDFlusher) error
 	// FlushMetricsMetaTo flushes tagKey, tagKeyId, fieldName, fieldID to flusher

--- a/tsdb/memdb/metric_store_index.go
+++ b/tsdb/memdb/metric_store_index.go
@@ -327,8 +327,13 @@ func (index *tagIndex) findSeriesIDsByRegex(entrySet *tagKVEntrySet, expr *stmt.
 	if err != nil {
 		return nil
 	}
+	// the regex pattern is regarded as a prefix string + pattern
+	literalPrefix, _ := pattern.LiteralPrefix()
 	union := roaring.New()
 	for value, bitmap := range entrySet.values {
+		if !strings.HasPrefix(value, literalPrefix) {
+			continue
+		}
 		if pattern.MatchString(value) {
 			union.Or(bitmap)
 		}

--- a/tsdb/memdb/metric_store_index_test.go
+++ b/tsdb/memdb/metric_store_index_test.go
@@ -183,6 +183,10 @@ func Test_tagIndex_findSeriesIDsByRegex(t *testing.T) {
 	// tag-value exist
 	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `b2[0-9]+`})
 	assert.Equal(t, uint64(2), bitmap.GetCardinality())
+	// literal prefix:22 not exist
+	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `22+`})
+	assert.Equal(t, uint64(0), bitmap.GetCardinality())
+
 }
 
 func Test_tagIndex_getSeriesIDsForTag(t *testing.T) {

--- a/tsdb/series/interface.go
+++ b/tsdb/series/interface.go
@@ -13,6 +13,17 @@ type MetaGetter interface {
 	GetTagValues(metricID uint32, tagKeys []string, version uint32) (tagValues [][]string, err error)
 }
 
+// Suggester represents the suggest ability for metricNames, tagKeys and tagValues.
+// default max limit of suggestions is set in constants
+type Suggester interface {
+	// SuggestMetrics returns suggestions from a given prefix of metricName
+	SuggestMetrics(metricPrefix string, limit int) []string
+	// SuggestTagKeys returns suggestions from given metricName and prefix of tagKey
+	SuggestTagKeys(metricName, tagKeyPrefix string, limit int) []string
+	// SuggestTagValues returns suggestions from given metricName, tagKey and prefix of tagValue
+	SuggestTagValues(metricName, tagKey, tagValuePrefix string, limit int) []string
+}
+
 // Filter represents the query ability for filtering seriesIDs by expr from an index of tags.
 // to support multi-version based on timestamp, time range for filtering spec version is necessary
 type Filter interface {

--- a/tsdb/tblstore/metrics_meta_reader_test.go
+++ b/tsdb/tblstore/metrics_meta_reader_test.go
@@ -92,6 +92,8 @@ func Test_MetricsMetaReader_ok(t *testing.T) {
 	tagID, ok := metaReader.ReadTagID(2, "a2")
 	assert.Equal(t, uint32(7), tagID)
 	assert.True(t, ok)
+	assert.Len(t, metaReader.SuggestTagKeys(2, "a", 100), 2)
+	assert.Len(t, metaReader.SuggestTagKeys(2, "a", 1), 1)
 	// tag not found
 	tagID, ok = metaReader.ReadTagID(2, "a3")
 	assert.Zero(t, tagID)
@@ -130,9 +132,9 @@ func Test_MetricsMetaReader_ReadMaxFieldID(t *testing.T) {
 
 	// mock corrupt data
 	data2 = append(data2, byte(32))
-	mockReader2.EXPECT().Get(uint32(2)).Return(data2)
+	mockReader2.EXPECT().Get(uint32(2)).Return(data2).Times(2)
 	assert.Equal(t, uint16(0), metaReader.ReadMaxFieldID(2))
-
+	assert.Nil(t, metaReader.SuggestTagKeys(2, "", 100))
 }
 
 func Test_MetricsMetaReader_readBlock_corrupt(t *testing.T) {


### PR DESCRIPTION
- add suggest methods for both memdb and indexdb: suggestMetrics based on art-tree, suggestTags based on index-meta table, suggestTagValues based on inverted index table;
- implement series.MetaGetter for memdb
- add benchmarks for on-disk trie-tree search
- optimize the performance of regex-search, the literal string of regex-pattern is regarded as prefix-search now
- remove `json` log format as it looks weird