### PR TITLE
[fix:#92][tsdb]: metaGetter returns tagValues by seriesIDs

### DIFF
--- a/pkg/collections/bit_array.go
+++ b/pkg/collections/bit_array.go
@@ -11,21 +11,20 @@ import (
 // Not thread-safe.
 type BitArray struct {
 	payload []byte
-	builder strings.Builder
 }
 
 // NewBitArray returns a new BitArray from buf.
-func NewBitArray(buf []byte) (*BitArray, error) {
-	if len(buf) > math.MaxUint16 {
-		return nil, fmt.Errorf("%d is too long for a bit array", len(buf))
-	}
-	return &BitArray{payload: buf}, nil
+func NewBitArray(buf []byte) *BitArray {
+	return &BitArray{payload: buf}
 }
 
 // Reset resets all payload to zero.
-func (ba *BitArray) Reset() {
-	ba.payload = ba.payload[:0]
-	ba.builder.Reset()
+func (ba *BitArray) Reset(buf []byte) {
+	if buf == nil {
+		ba.payload = ba.payload[:0]
+		return
+	}
+	ba.payload = buf
 }
 
 // SetBit sets a bit at the given index.
@@ -61,14 +60,13 @@ func (ba *BitArray) Len() int {
 }
 
 // String implements stringer.
-// Inefficient function, just for test and debug
 func (ba *BitArray) String() string {
-	ba.builder.Reset()
+	var builder strings.Builder
 	for _, val := range ba.payload {
 		section := []byte(fmt.Sprintf("%08b", val))
 		for i := 0; i < len(section); i++ {
-			ba.builder.WriteByte(section[len(section)-i-1])
+			builder.WriteByte(section[len(section)-i-1])
 		}
 	}
-	return ba.builder.String()
+	return builder.String()
 }

--- a/pkg/collections/bit_array_test.go
+++ b/pkg/collections/bit_array_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func Test_BitArray(t *testing.T) {
-	ba, err := NewBitArray(nil)
-	assert.Nil(t, err)
+	ba := NewBitArray(nil)
 	assert.Equal(t, "", ba.String())
 	assert.False(t, ba.GetBit(0))
 
@@ -36,21 +35,15 @@ func Test_BitArray(t *testing.T) {
 	assert.False(t, ba.GetBit(24))
 	assert.False(t, ba.GetBit(800))
 
-	ba.Reset()
+	ba.Reset(nil)
 	assert.False(t, ba.GetBit(0))
 
-	buf := make([]byte, 65537)
-	ba2, err := NewBitArray(buf)
-	assert.Nil(t, ba2)
-	assert.NotNil(t, err)
-
-	buf = make([]byte, 2)
-	ba2, err = NewBitArray(buf)
-	assert.Nil(t, err)
+	ba2 := NewBitArray(nil)
+	ba2.Reset([]byte{255, 255})
 	assert.NotNil(t, ba2)
+	assert.True(t, ba2.GetBit(0))
 
-	ba3, err := NewBitArray([]byte{})
-	assert.Nil(t, err)
+	ba3 := NewBitArray([]byte{})
 	assert.NotNil(t, ba3)
 	assert.False(t, ba3.GetBit(23))
 

--- a/query/scan_worker.go
+++ b/query/scan_worker.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/RoaringBitmap/roaring"
+
 	"github.com/lindb/lindb/pkg/logger"
 	"github.com/lindb/lindb/series"
 )
@@ -132,7 +134,7 @@ func (s *scanWorker) handleEvent(event *series.FieldEvent) error {
 
 // getGroupByTagValues gets group by tag values
 func (s *scanWorker) getGroupByTagValues(version series.Version, seriesID uint32) error {
-	_, err := s.metaGetter.GetTagValues(s.metricID, s.tagKeys, version)
+	_, err := s.metaGetter.GetTagValues(s.metricID, s.tagKeys, version, roaring.BitmapOf(seriesID))
 	fmt.Println(version)
 	fmt.Println(seriesID)
 	if err != nil {

--- a/query/scan_worker_test.go
+++ b/query/scan_worker_test.go
@@ -82,11 +82,11 @@ func TestScanWorker_GroupBy(t *testing.T) {
 	worker := createScanWorker(context.TODO(), uint32(10), []string{"host", "disk"}, metaGetter, aggWorker)
 	gomock.InOrder(
 		aggWorker.EXPECT().emit(gomock.Any()),
-		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any()).Return(nil, nil),
+		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 		aggWorker.EXPECT().emit(gomock.Any()),
 		aggWorker.EXPECT().sendResult(gomock.Any()),
 		aggWorker.EXPECT().emit(gomock.Any()),
-		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any()).Return(nil, nil),
+		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 		aggWorker.EXPECT().sendResult(gomock.Any()),
 		aggWorker.EXPECT().close(),
 	)
@@ -130,7 +130,7 @@ func TestScanWorker_GroupBy(t *testing.T) {
 	worker = createScanWorker(context.TODO(), uint32(10), []string{"host", "disk"}, metaGetter, aggWorker)
 	gomock.InOrder(
 		aggWorker.EXPECT().emit(gomock.Any()),
-		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("err")),
+		metaGetter.EXPECT().GetTagValues(uint32(10), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("err")),
 		aggWorker.EXPECT().close().AnyTimes(),
 	)
 	worker.Emit(&series.FieldEvent{

--- a/series/interface.go
+++ b/series/interface.go
@@ -1,6 +1,8 @@
 package series
 
 import (
+	"github.com/RoaringBitmap/roaring"
+
 	"github.com/lindb/lindb/pkg/timeutil"
 	"github.com/lindb/lindb/sql/stmt"
 )
@@ -10,7 +12,8 @@ import (
 // MetaGetter represents the query ability for metric level metadata
 type MetaGetter interface {
 	// GetTagValues returns tag values by tag keys and spec version for metric level
-	GetTagValues(metricID uint32, tagKeys []string, version Version) (tagValues [][]string, err error)
+	GetTagValues(metricID uint32, tagKeys []string, version Version, seriesIDs *roaring.Bitmap) (
+		seriesID2TagValues map[uint32][]string, err error)
 }
 
 // Suggester represents the suggest ability for metricNames, tagKeys and tagValues.
@@ -34,6 +37,3 @@ type Filter interface {
 	GetSeriesIDsForTag(metricID uint32, tagKey string, timeRange timeutil.TimeRange) (
 		*MultiVerSeriesIDSet, error)
 }
-
-// DataGetter represents the query ability for querying data of the seriesIDs
-type DataGetter interface{}

--- a/tsdb/diskdb/index_database.go
+++ b/tsdb/diskdb/index_database.go
@@ -1,6 +1,8 @@
 package diskdb
 
 import (
+	"github.com/RoaringBitmap/roaring"
+
 	"github.com/lindb/lindb/constants"
 	"github.com/lindb/lindb/kv"
 	"github.com/lindb/lindb/pkg/timeutil"
@@ -55,18 +57,18 @@ func (db *indexDatabase) GetTagValues(
 	metricID uint32,
 	tagKeys []string,
 	version series.Version,
+	seriesIDs *roaring.Bitmap,
 ) (
-	tagValues [][]string,
+	seriesID2TagValues map[uint32][]string,
 	err error,
 ) {
-
 	snapShot := db.invertedIndexFamily.GetSnapshot()
 	defer snapShot.Close()
 	readers, err := snapShot.FindReaders(metricID)
 	if err != nil {
 		return nil, err
 	}
-	return tblstore.NewForwardIndexReader(readers).GetTagValues(metricID, tagKeys, version)
+	return tblstore.NewForwardIndexReader(readers).GetTagValues(metricID, tagKeys, version, seriesIDs)
 }
 
 // FindSeriesIDsByExpr finds series ids by tag filter expr for metric id

--- a/tsdb/diskdb/index_database_test.go
+++ b/tsdb/diskdb/index_database_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lindb/lindb/kv/version"
 	"github.com/lindb/lindb/pkg/timeutil"
 
+	"github.com/RoaringBitmap/roaring"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,14 +59,14 @@ func Test_IndexDatabase_GetTagValues(t *testing.T) {
 
 	// case1: snapshot FindReaders error
 	mockedDB.WithFindReadersError()
-	tagValues, err := mockedDB.indexDatabase.GetTagValues(1, nil, 1)
+	tagValues, err := mockedDB.indexDatabase.GetTagValues(1, nil, 1, roaring.New())
 	assert.Nil(t, tagValues)
 	assert.NotNil(t, err)
 	// case2: snapshot FindReaders ok
 	mockedDB.WithFindReadersOK()
 	mockedDB.reader.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
-	_, err = mockedDB.indexDatabase.GetTagValues(1, nil, 1)
-	assert.Nil(t, err)
+	_, err = mockedDB.indexDatabase.GetTagValues(1, nil, 1, roaring.New())
+	assert.NotNil(t, err)
 }
 
 func Test_IndexDatabase_SuggestTagValues(t *testing.T) {

--- a/tsdb/doc.go
+++ b/tsdb/doc.go
@@ -131,12 +131,12 @@ v--------+--------+--------+--------+--------v       v--------+---+--------v----
 +--------+--------+--------+--------+--------+       +--------+---+--------+-------+
          │        │
          │        │
-  +------+        +---------------------------------------------------+
- /                 Level3                                              \
-v--------+--------+--------+--------+--------+--------+--------+--------v
-│  Time  │ TagKeys│ Dict   │TagKeys │ Series │Offsets │SeriesID│ Footer │
-│  Range │ Block  │ Block  │LUTBlock│LUTBlock│ Block  │ BitMap │        │
-+--------+--------+--------+--------+--------+--------+--------+--------+
+  +------+        +------------------------------------------+
+ /                 Level3                                     \
+v--------+--------+--------+--------+--------+--------+--------v
+│  Time  │ TagKeys│ Dict   │ Series │Offsets │SeriesID│ Footer │
+│  Range │ Block  │ Block  │LUTBlock│ Block  │ BitMap │        │
++--------+--------+--------+--------+--------+--------+--------+
 
 Level1(KV table: MetricID -> MetricBlock)
 Level1 is same as MetricDataTable as below
@@ -166,7 +166,6 @@ TagKeysBlock stores all tagKeys of the metric
                                                                                            │          │
                                                                                          PosOfTags1 PosOfTags2
 
-
 Level3(Dict Block)
 Dict Block is composed of 2 parts:
 1) String Block Offsets
@@ -188,21 +187,6 @@ Dict Block is composed of 2 parts:
                 StrBlock1Length                      PosOfDictBlockOffsets
 
 
-Level3(TagKeys LOOKUP-TABLE Block)
-This block provides a ability to filter tagValues by a specified tagKeys
-
-┌────────────────────────────────────────────────────────────────────────────┐
-│                          Keys LOOKUP-TABLE Block                           │
-├──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┤
-│  Key1    │Key1Values│ Value1Of │ Value2Of │  Key2    │Key2Values│ Value1Of │
-│  Length  │   Count  │   Key1   │   Key1   │  Length  │   Count  │   Key2   │
-├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-│ uvariant │ uvariant │ uvariant │ uvariant │ uvariant │ uvariant │ uvariant │
-^──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
-│
-PosOfKeysLUT
-
-
 Level3(Series TagsKeyValue LOOKUP-TABLE Block)
 SeriesTagsBlock is composed of 2 parts:
 1) bit-array of tagKeys of this seriesID
@@ -216,7 +200,7 @@ SeriesTagsBlock is composed of 2 parts:
 ┌──────────────────────────────────────────────────────┐
 │             Series Tags LOOKUP-TABLE Block           │
 ├──────────┬──────────┬──────────┬──────────┬──────────┤
-│ TagsKey  │ StrBlock │ StrBlock │ StrBlock │ StrBlock │
+│ TagKeys  │ StrBlock │ StrBlock │ StrBlock │ StrBlock │
 │ BitArray │ Sequence1│ Sequence2│ Sequence3│ Sequence4│
 ├──────────┼──────────┼──────────┼──────────┼──────────┤
 │ N Bytes  │ uvariant │ uvariant │ uvariant │ uvariant │
@@ -224,14 +208,14 @@ SeriesTagsBlock is composed of 2 parts:
 
 
 Level3(Footer)
-┌───────────────────────────────────────────┐
-│                   Footer                  │
-├──────────┬──────────┬──────────┬──────────┤
-│PosOfDictB│ PosOfKeys│ PosOfOff │  PosOf   │
-│lockOffset│   LUT    │ setBlock │  BitMap  │
-├──────────┼──────────┼──────────┼──────────┤
-│ 4 Bytes  │ 4 Bytes  │ 4 Bytes  │  4 Bytes │
-└──────────┴──────────┴──────────┴──────────┘
+┌────────────────────────────────┐
+│              Footer            │
+├──────────┬──────────┬──────────┤
+│PosOfDictB│ PosOfOff │  PosOf   │
+│lockOffset│ setBlock │  BitMap  │
+├──────────┼──────────┼──────────┤
+│ 4 Bytes  │ 4 Bytes  │  4 Bytes │
+└──────────┴──────────┴──────────┘
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━Layout of Series Inverted Index Table━━━━━━━━━━━━━━━━━━━━━━━━

--- a/tsdb/memdb/database.go
+++ b/tsdb/memdb/database.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/RoaringBitmap/roaring"
+
 	"github.com/lindb/lindb/pkg/interval"
 	"github.com/lindb/lindb/pkg/logger"
 	"github.com/lindb/lindb/pkg/timeutil"
@@ -471,14 +473,21 @@ func (md *memoryDatabase) GetSeriesIDsForTag(
 }
 
 // GetTagValues returns tag values by tag keys and spec version for metric level from memory-database
-func (md *memoryDatabase) GetTagValues(metricID uint32, tagKeys []string, version series.Version) (
-	tagValues [][]string, err error) {
+func (md *memoryDatabase) GetTagValues(
+	metricID uint32,
+	tagKeys []string,
+	version series.Version,
+	seriesIDs *roaring.Bitmap,
+) (
+	seriesID2TagValues map[uint32][]string,
+	err error,
+) {
 	// get hash of metricId
 	mStore, ok := md.getMStoreByMetricID(metricID)
 	if !ok {
 		return nil, series.ErrNotFound
 	}
-	return mStore.getTagValues(tagKeys, version)
+	return mStore.getTagValues(tagKeys, version, seriesIDs)
 }
 
 // SuggestMetrics returns nil, as the index-db contains all metricNames

--- a/tsdb/memdb/database_test.go
+++ b/tsdb/memdb/database_test.go
@@ -273,15 +273,15 @@ func Test_MemoryDatabase_GetTagValues(t *testing.T) {
 	md := mdINTF.(*memoryDatabase)
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().getTagValues(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().getTagValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	md.getBucket(3333).hash2MStore[3333] = mockMStore
 	md.metricID2Hash.Store(uint32(3333), uint64(3333))
 
 	// existed metricID
-	_, err := mdINTF.GetTagValues(3333, nil, 1)
+	_, err := mdINTF.GetTagValues(3333, nil, 1, nil)
 	assert.Nil(t, err)
 	// inexisted metricID
-	_, err = mdINTF.GetTagValues(3334, nil, 1)
+	_, err = mdINTF.GetTagValues(3334, nil, 1, nil)
 	assert.NotNil(t, err)
 
 }

--- a/tsdb/tblstore/forward_index_merger.go
+++ b/tsdb/tblstore/forward_index_merger.go
@@ -29,7 +29,7 @@ func NewForwardIndexMerger(ttl time.Duration) kv.Merger {
 }
 
 func (m *forwardIndexMerger) Reset() {
-	m.flusher.resetMetricBlockContext()
+	m.flusher.Reset()
 	for version := range m.versionBlocksMap {
 		delete(m.versionBlocksMap, version)
 	}

--- a/tsdb/tblstore/metrics_data_flusher.go
+++ b/tsdb/tblstore/metrics_data_flusher.go
@@ -211,9 +211,8 @@ type entryBuilder struct {
 
 // newSeriesEntryBuilder returns a new entryBuilder, default first 2 byte is the column count.
 func newSeriesEntryBuilder() *entryBuilder {
-	bitArray, _ := collections.NewBitArray(nil)
 	return &entryBuilder{
-		bitArray:   bitArray,
+		bitArray:   collections.NewBitArray(nil),
 		dataWriter: stream.NewBufferWriter(nil),
 		lenWriter:  stream.NewBufferWriter(nil),
 		fieldsData: make(map[uint16][]byte)}
@@ -277,7 +276,7 @@ func (entryBuilder *entryBuilder) bytes(metaFieldsID []uint16) []byte {
 func (entryBuilder *entryBuilder) reset() {
 	entryBuilder.dataWriter.Reset()
 	entryBuilder.lenWriter.Reset()
-	entryBuilder.bitArray.Reset()
+	entryBuilder.bitArray.Reset(nil)
 	entryBuilder.fieldsData = make(map[uint16][]byte)
 	entryBuilder.minStartTime = 0
 	entryBuilder.maxEndTime = 0


### PR DESCRIPTION
new MetaGetter interface
GetTagValues(metricID uint32, tagKeys []string, version Version, seriesIDs *roaring.Bitmap) (
		seriesID2TagValues map[uint32][]string, err error)