### PR TITLE
[feat:#194][tsdb:tblstore]: merger of InvertedIndexTable

### DIFF
--- a/kv/version/edit_log.go
+++ b/kv/version/edit_log.go
@@ -78,7 +78,7 @@ func (el *EditLog) unmarshal(buf []byte) error {
 		}
 		l := fn()
 		length := int(reader.ReadUvarint32())
-		logData := reader.ReadBytes(length)
+		logData := reader.ReadSlice(length)
 		if err := l.Decode(logData); err != nil {
 			return fmt.Errorf("unmarshal log data error, type is:[%d],error:%s", logType, err)
 		}

--- a/pkg/encoding/tsd.go
+++ b/pkg/encoding/tsd.go
@@ -120,10 +120,10 @@ func (d *TSDDecoder) Reset(data []byte) {
 	d.endTime = d.startTime + d.count - 1
 
 	length := d.reader.ReadUvarint32()
-	d.timeSlots.Reset(d.reader.ReadBytes(int(length)))
+	d.timeSlots.Reset(d.reader.ReadSlice(int(length)))
 
 	length = d.reader.ReadUvarint32()
-	d.values.Reset(d.reader.ReadBytes(int(length)))
+	d.values.Reset(d.reader.ReadSlice(int(length)))
 }
 
 // Error returns decode error

--- a/series/version.go
+++ b/series/version.go
@@ -29,3 +29,28 @@ func (v Version) Time() time.Time {
 func (v Version) Elapsed() time.Duration {
 	return time.Since(v.Time())
 }
+
+// IsExpired detects if this version has been expired
+func (v Version) IsExpired(ttl time.Duration) bool {
+	return v.Time().Add(ttl).Before(time.Now())
+}
+
+// Before returns if this version is before other.
+func (v Version) Before(other Version) bool {
+	return v < other
+}
+
+// Before returns if this version is after other.
+func (v Version) After(other Version) bool {
+	return v > other
+}
+
+// Before checks if this version is equals to other.
+func (v Version) Equal(other Version) bool {
+	return v == other
+}
+
+// String implements Stringer
+func (v Version) String() string {
+	return v.Time().Format("2006-01-02 15:04:05")
+}

--- a/series/version_test.go
+++ b/series/version_test.go
@@ -2,6 +2,7 @@ package series
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -9,4 +10,14 @@ import (
 func Test_Version(t *testing.T) {
 	v := NewVersion()
 	assert.True(t, v.Elapsed().Seconds() < float64(1))
+
+	v1 := Version(0)
+	assert.True(t, v1.IsExpired(time.Hour))
+
+	v2 := Version(1)
+	assert.True(t, v1.Before(v2))
+	assert.False(t, v1.After(v2))
+	assert.False(t, v1.Equal(v2))
+
+	t.Log(v2.String())
 }

--- a/storage/handler/writer.go
+++ b/storage/handler/writer.go
@@ -132,7 +132,7 @@ func (w *Writer) handleReplica(shard tsdb.Shard, replica *storage.Replica) {
 	for !reader.Empty() {
 		bytesLen := reader.ReadUvarint32()
 
-		bytes := reader.ReadBytes(int(bytesLen))
+		bytes := reader.ReadSlice(int(bytesLen))
 
 		if err := reader.Error(); err != nil {
 			w.logger.Error("read metricList bytes from replica", logger.Error(err))

--- a/tsdb/memdb/metric_store.go
+++ b/tsdb/memdb/metric_store.go
@@ -502,7 +502,7 @@ func (ms *metricStore) flushInvertedIndexTo(flusher tblstore.InvertedIndexFlushe
 			}
 			flusher.FlushTagValue(tagValue)
 		}
-		if err := flusher.FlushTagID(idGenerator.GenTagKeyID(ms.metricID, tagKey)); err != nil {
+		if err := flusher.FlushTagKeyID(idGenerator.GenTagKeyID(ms.metricID, tagKey)); err != nil {
 			return err
 		}
 	}

--- a/tsdb/memdb/metric_store_test.go
+++ b/tsdb/memdb/metric_store_test.go
@@ -207,8 +207,8 @@ func Test_mStore_findSeriesIDsByExpr_getSeriesIDsForTag(t *testing.T) {
 	returnNotNil2 := mockTagIdx.EXPECT().getSeriesIDsForTag(gomock.Any()).Return(roaring.New()).Times(2)
 	returnNil2 := mockTagIdx.EXPECT().getSeriesIDsForTag(gomock.Any()).Return(nil).Times(2)
 	gomock.InOrder(returnNotNil2, returnNil2)
-	mStoreInterface.getSeriesIDsForTag("")
-	mStoreInterface.getSeriesIDsForTag("")
+	_, _ = mStoreInterface.getSeriesIDsForTag("")
+	_, _ = mStoreInterface.getSeriesIDsForTag("")
 }
 
 func Test_getFieldIDOrGenerate(t *testing.T) {
@@ -254,9 +254,9 @@ func Test_getFieldIDOrGenerate_special_case(t *testing.T) {
 	mockGen.EXPECT().GenFieldID(uint32(100), "1", field.SumField).Return(uint16(1), nil).AnyTimes()
 	mockGen.EXPECT().GenFieldID(uint32(100), "2", field.SumField).Return(uint16(2), nil).AnyTimes()
 	mockGen.EXPECT().GenFieldID(uint32(100), "3", field.SumField).Return(uint16(3), nil).AnyTimes()
-	mStoreInterface.getFieldIDOrGenerate("3", field.SumField, mockGen)
-	mStoreInterface.getFieldIDOrGenerate("1", field.SumField, mockGen)
-	mStoreInterface.getFieldIDOrGenerate("2", field.SumField, mockGen)
+	_, _ = mStoreInterface.getFieldIDOrGenerate("3", field.SumField, mockGen)
+	_, _ = mStoreInterface.getFieldIDOrGenerate("1", field.SumField, mockGen)
+	_, _ = mStoreInterface.getFieldIDOrGenerate("2", field.SumField, mockGen)
 }
 
 func prepareMockTagIndexes(ctrl *gomock.Controller) (*MocktagIndexINTF, *MocktagIndexINTF, *MocktagIndexINTF) {
@@ -331,10 +331,10 @@ func Test_mStore_flushInvertedIndexTo(t *testing.T) {
 	//////////////////////////////////////////////
 	mStore.mutable = mockTagIdx1
 	// flush ok
-	mockTableFlusher.EXPECT().FlushTagID(gomock.Any()).Return(nil).Times(2)
+	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(nil).Times(2)
 	assert.Nil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 	// flush error
-	mockTableFlusher.EXPECT().FlushTagID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
+	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
 	assert.NotNil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 
 	//////////////////////////////////////////////
@@ -343,10 +343,10 @@ func Test_mStore_flushInvertedIndexTo(t *testing.T) {
 	mStore.immutable = []tagIndexINTF{mockTagIdx1, mockTagIdx2}
 	mStore.mutable = mockTagIdx3
 	// flush error
-	mockTableFlusher.EXPECT().FlushTagID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
+	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
 	assert.NotNil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 	// flush ok
-	mockTableFlusher.EXPECT().FlushTagID(gomock.Any()).Return(nil).Times(4)
+	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(nil).Times(4)
 	assert.Nil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 }
 

--- a/tsdb/tblstore/inverted_index_flusher_test.go
+++ b/tsdb/tblstore/inverted_index_flusher_test.go
@@ -25,7 +25,7 @@ func Test_InvertedIndexFlusher_Commit(t *testing.T) {
 
 	// mock commit ok
 	mockFlusher.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	err := indexFlusher.FlushTagID(333)
+	err := indexFlusher.FlushTagKeyID(333)
 	assert.Nil(t, err)
 }
 
@@ -54,11 +54,11 @@ func Test_InvertedIndexFlusher_RS_error(t *testing.T) {
 
 	// mock isPrefixKey error
 	mockRS.EXPECT().MarshalBinary().Return(nil, fmt.Errorf("error1"))
-	assert.NotNil(t, indexFlusher.FlushTagID(11))
+	assert.NotNil(t, indexFlusher.FlushTagKeyID(11))
 	// mock LOUDS error
 	mockRS.EXPECT().MarshalBinary().Return([]byte("12345"), nil)
 	mockRS.EXPECT().MarshalBinary().Return(nil, fmt.Errorf("error2"))
-	assert.NotNil(t, indexFlusher.FlushTagID(11))
+	assert.NotNil(t, indexFlusher.FlushTagKeyID(11))
 }
 
 func Test_SeriesIndexFlusher_OK(t *testing.T) {
@@ -81,6 +81,6 @@ func Test_SeriesIndexFlusher_OK(t *testing.T) {
 	indexFlusher.FlushVersion(3, 22, 24, roaring.New())
 	// flush tagValue2
 	indexFlusher.FlushTagValue("2")
-	// flush tagKey
-	assert.Nil(t, indexFlusher.FlushTagID(0))
+	// flush tagKeyID
+	assert.Nil(t, indexFlusher.FlushTagKeyID(0))
 }

--- a/tsdb/tblstore/inverted_index_merger.go
+++ b/tsdb/tblstore/inverted_index_merger.go
@@ -1,0 +1,148 @@
+package tblstore
+
+import (
+	"sort"
+	"time"
+
+	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/series"
+)
+
+type invertedIndexMerger struct {
+	flusher      *invertedIndexFlusher
+	reader       *invertedIndexReader
+	nopKVFlusher *kv.NopFlusher
+	ttl          time.Duration
+}
+
+func NewInvertedIndexMerger(ttl time.Duration) kv.Merger {
+	nopKVFlusher := kv.NewNopFlusher()
+	return &invertedIndexMerger{
+		flusher:      NewInvertedIndexFlusher(nopKVFlusher).(*invertedIndexFlusher),
+		reader:       NewInvertedIndexReader(nil).(*invertedIndexReader),
+		nopKVFlusher: nopKVFlusher,
+		ttl:          ttl}
+}
+
+func (m *invertedIndexMerger) reset() {
+	m.flusher.reset()
+}
+
+func (m *invertedIndexMerger) Merge(
+	key uint32,
+	value [][]byte,
+) (
+	[]byte,
+	error,
+) {
+	defer m.reset()
+	var (
+		tagValueData = make(map[string]*[]versionedTagValueData)
+	)
+	// extract
+	for _, block := range value {
+		var (
+			offsets         []int
+			offsetTagValues = make(map[int]string)
+		)
+		entrySet, err := newTagKVEntrySet(block)
+		if err != nil {
+			return nil, err
+		}
+		tree, err := entrySet.TrieTree()
+		if err != nil {
+			return nil, err
+		}
+		// read offsets
+		itr := tree.Iterator("")
+		for itr.HasNext() {
+			value, offset := itr.Next()
+			offsetTagValues[offset] = value
+			offsets = append(offsets, offset)
+		}
+		// read all positions
+		offsetPositions, err := entrySet.OffsetsToPosition(offsets)
+		if err != nil {
+			return nil, err
+		}
+		for offset, pos := range offsetPositions {
+			dataList, err := entrySet.ReadTagValueDataBlock(pos)
+			if err != nil {
+				return nil, err
+			}
+			tagValue := offsetTagValues[offset]
+
+			dataUnionList, ok := tagValueData[tagValue]
+			if ok {
+				*dataUnionList = append(*dataUnionList, dataList...)
+			} else {
+				dataUnionList = &[]versionedTagValueData{}
+				*dataUnionList = append(*dataUnionList, dataList...)
+			}
+			tagValueData[tagValue] = dataUnionList
+		}
+	}
+	// do ttl
+	m.evictOldVersion(tagValueData)
+	// do flush
+	m.flush(tagValueData, key)
+	return m.nopKVFlusher.Bytes(), nil
+}
+
+func (m *invertedIndexMerger) evictOldVersion(
+	tagValueData map[string]*[]versionedTagValueData,
+) {
+	var latestVersion series.Version
+	// sort and pick the latestVersion
+	for _, dataList := range tagValueData {
+		// desc order
+		dataList := dataList
+		sort.Slice(*dataList, func(i, j int) bool {
+			return (*dataList)[i].version.After((*dataList)[j].version)
+		})
+		thisLatestVersion := (*dataList)[0].version
+		if thisLatestVersion.After(latestVersion) {
+			latestVersion = thisLatestVersion
+		}
+	}
+	for tagValue, dataList := range tagValueData {
+		var lastAliveIndex = len(*dataList)
+		for index, data := range *dataList {
+			// expire
+			if data.version.IsExpired(m.ttl) {
+				lastAliveIndex = index
+				break
+			}
+		}
+		// case1: all versions expired, but it's the latest version in use
+		if lastAliveIndex == 0 && (*dataList)[0].version.Equal(latestVersion) {
+			// remove expired versions
+			lastAliveIndex = 1
+		}
+		// delete all versions
+		if lastAliveIndex == 0 {
+			delete(tagValueData, tagValue)
+			continue
+		}
+		// remove expired versions
+		*dataList = (*dataList)[:lastAliveIndex]
+	}
+}
+
+func (m *invertedIndexMerger) flush(
+	tagValueData map[string]*[]versionedTagValueData,
+	tagKeyID uint32,
+) {
+	for tagValue, dataList := range tagValueData {
+		for _, data := range *dataList {
+			timeRange := data.TimeRange()
+			m.flusher.flushVersion(
+				data.version,
+				uint32(timeRange.Start/1000),
+				uint32(timeRange.End/1000),
+				data.bitMapData)
+		}
+		m.flusher.FlushTagValue(tagValue)
+	}
+	_ = m.flusher.FlushTagKeyID(tagKeyID)
+}

--- a/tsdb/tblstore/inverted_index_merger_test.go
+++ b/tsdb/tblstore/inverted_index_merger_test.go
@@ -1,0 +1,89 @@
+package tblstore
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/pkg/timeutil"
+	"github.com/lindb/lindb/series"
+)
+
+func buildInvertedIndexBlockToCompact() (data [][]byte) {
+	nopKVFlusher := kv.NewNopFlusher()
+	now := timeutil.Now()
+
+	// ttl: 30 day
+	tagValueVersions1 := map[string]map[series.Version]*roaring.Bitmap{
+		"192.168.1.1": {
+			series.Version(now - 25*timeutil.OneDay): roaring.BitmapOf(1, 2, 3),
+			series.Version(now - 35*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)},
+		"192.168.1.2": {
+			series.Version(now - 12*timeutil.OneDay): roaring.BitmapOf(1, 2, 3),
+			series.Version(now - 32*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)},
+		"192.168.1.3": {
+			series.Version(now - 35*timeutil.OneDay): roaring.BitmapOf(1, 2, 3),
+			series.Version(now - 36*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)}}
+	tagValueVersions2 := map[string]map[series.Version]*roaring.Bitmap{
+		"192.168.1.1": {
+			series.Version(now - 15*timeutil.OneDay): roaring.BitmapOf(1, 2, 3),
+			series.Version(now - 35*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)},
+		"192.168.1.3": {
+			series.Version(now - 20*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)},
+		"192.168.1.4": {
+			series.Version(now - 36*timeutil.OneDay): roaring.BitmapOf(1, 2, 3)}}
+	getFlushedData := func(tagValueVersions map[string]map[series.Version]*roaring.Bitmap) []byte {
+		flusher := NewInvertedIndexFlusher(nopKVFlusher).(*invertedIndexFlusher)
+		for tagValue, versions := range tagValueVersions {
+			for version, bitmap := range versions {
+				flusher.FlushVersion(version, 1, 1, bitmap)
+			}
+			flusher.FlushTagValue(tagValue)
+		}
+		_ = flusher.FlushTagKeyID(1)
+		return append([]byte{}, nopKVFlusher.Bytes()...)
+	}
+
+	data = append(data, getFlushedData(tagValueVersions1), getFlushedData(tagValueVersions2))
+	return data
+}
+
+func TestInvertedIndexMerger_Merge_TTL_30Day(t *testing.T) {
+	m := NewInvertedIndexMerger(time.Hour * 24 * 30).(*invertedIndexMerger)
+	compacted, err := m.Merge(1, buildInvertedIndexBlockToCompact())
+	assert.Nil(t, err)
+	assert.NotNil(t, compacted)
+	// convert to entrySet
+	entrySet, err := newTagKVEntrySet(compacted)
+	assert.Nil(t, err)
+	tree, err := entrySet.TrieTree()
+	assert.Nil(t, err)
+	tagValues := tree.PrefixSearch("", 10)
+	sort.Slice(tagValues, func(i, j int) bool { return tagValues[i] < tagValues[j] })
+	assert.Equal(t, []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"}, tagValues)
+}
+
+func TestInvertedIndexMerger_Merge_TTL_10Day(t *testing.T) {
+	m := NewInvertedIndexMerger(time.Hour * 24 * 10).(*invertedIndexMerger)
+	compacted, err := m.Merge(1, buildInvertedIndexBlockToCompact())
+	assert.Nil(t, err)
+	assert.NotNil(t, compacted)
+	// convert to entrySet
+	entrySet, err := newTagKVEntrySet(compacted)
+	assert.Nil(t, err)
+	tree, err := entrySet.TrieTree()
+	assert.Nil(t, err)
+	tagValues := tree.PrefixSearch("", 10)
+	assert.Equal(t, []string{"192.168.1.2"}, tagValues)
+}
+
+func TestInvertedIndexMerger_Merge_BadBlock(t *testing.T) {
+	m := NewInvertedIndexMerger(time.Hour * 24 * 10).(*invertedIndexMerger)
+	compacted, err := m.Merge(1, [][]byte{{1, 2, 3, 4}, {1, 2, 3, 4}})
+	assert.NotNil(t, err)
+	assert.Nil(t, compacted)
+}

--- a/tsdb/tblstore/inverted_index_reader_test.go
+++ b/tsdb/tblstore/inverted_index_reader_test.go
@@ -1,6 +1,7 @@
 package tblstore
 
 import (
+	"math"
 	"testing"
 
 	"github.com/lindb/lindb/kv"
@@ -49,45 +50,45 @@ func buildInvertedIndexBlock() (zoneBlock []byte, ipBlock []byte, hostBlock []by
 	// flush zone tag, tagID: 20
 	/////////////////////////
 	for zone, ids := range zoneMapping {
-		for v := uint32(1500000000); v < 1800000000; v += 100000000 {
+		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.AddMany(ids)
-			seriesFlusher.FlushVersion(series.Version(v), v+10000, v+20000, bitmap)
+			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
 		}
 		seriesFlusher.FlushTagValue(zone)
 	}
 	// pick the zoneBlock buffer
-	_ = seriesFlusher.FlushTagID(20)
+	_ = seriesFlusher.FlushTagKeyID(20)
 	zoneBlock = append(zoneBlock, nopKVFlusher.Bytes()...)
 
 	/////////////////////////
 	// flush ip tag, tagID: 21
 	/////////////////////////
 	for seriesID, ip := range ipMapping {
-		for v := uint32(1500000000); v < 1800000000; v += 100000000 {
+		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.Add(seriesID)
-			seriesFlusher.FlushVersion(series.Version(v), v+10000, v+20000, bitmap)
+			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
 		}
 		seriesFlusher.FlushTagValue(ip)
 	}
 	// pick the ipBlock buffer
-	_ = seriesFlusher.FlushTagID(21)
+	_ = seriesFlusher.FlushTagKeyID(21)
 	ipBlock = append(ipBlock, nopKVFlusher.Bytes()...)
 
 	/////////////////////////
 	// flush host tag, tagID: 22
 	/////////////////////////
 	for seriesID, host := range hostMapping {
-		for v := uint32(1500000000); v < 1800000000; v += 100000000 {
+		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.Add(seriesID)
-			seriesFlusher.FlushVersion(series.Version(v), v+10000, v+20000, bitmap)
+			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
 		}
 		seriesFlusher.FlushTagValue(host)
 	}
 	// pick the hostBlock buffer
-	_ = seriesFlusher.FlushTagID(22)
+	_ = seriesFlusher.FlushTagKeyID(22)
 	hostBlock = append(hostBlock, nopKVFlusher.Bytes()...)
 	return zoneBlock, ipBlock, hostBlock
 }
@@ -113,6 +114,7 @@ func Test_InvertedIndexReader_GetSeriesIDsForTagID(t *testing.T) {
 	idSet, err := reader.GetSeriesIDsForTagKeyID(19, timeutil.TimeRange{})
 	assert.NotNil(t, err)
 	assert.Nil(t, idSet)
+
 	// read zone block but not overlaps
 	idSet, err = reader.GetSeriesIDsForTagKeyID(20,
 		timeutil.TimeRange{
@@ -120,6 +122,7 @@ func Test_InvertedIndexReader_GetSeriesIDsForTagID(t *testing.T) {
 			End:   1500000000 * 1000})
 	assert.NotNil(t, err)
 	assert.Nil(t, idSet)
+
 	// read zone block, overlaps
 	idSet, err = reader.GetSeriesIDsForTagKeyID(20,
 		timeutil.TimeRange{
@@ -127,10 +130,9 @@ func Test_InvertedIndexReader_GetSeriesIDsForTagID(t *testing.T) {
 			End:   1600000000 * 1000})
 	assert.Nil(t, err)
 	assert.NotNil(t, idSet)
-
-	assert.Contains(t, idSet.Versions(), series.Version(1500000000))
-	assert.Equal(t, uint32(1), idSet.Versions()[series.Version(1500000000)].Minimum())
-	assert.Equal(t, uint32(9), idSet.Versions()[series.Version(1500000000)].Maximum())
+	assert.Contains(t, idSet.Versions(), series.Version(1500000000000))
+	assert.Equal(t, uint32(1), idSet.Versions()[series.Version(1500000000000)].Minimum())
+	assert.Equal(t, uint32(9), idSet.Versions()[series.Version(1500000000000)].Maximum())
 }
 
 func Test_intSliceContains(t *testing.T) {
@@ -173,9 +175,9 @@ func Test_InvertedIndexReader_FindSeriesIDsByExprForTagID_EqualExpr(t *testing.T
 	idSet, err := reader.FindSeriesIDsByExprForTagKeyID(22, &stmt.EqualsExpr{Key: "host", Value: "eleme-dev-sh-4"},
 		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
 	assert.Nil(t, err)
-	assert.Contains(t, idSet.Versions(), series.Version(1500000000))
-	assert.Equal(t, uint64(1), idSet.Versions()[1500000000].GetCardinality())
-	assert.True(t, idSet.Versions()[series.Version(1500000000)].Contains(4))
+	assert.Contains(t, idSet.Versions(), series.Version(1500000000000))
+	assert.Equal(t, uint64(1), idSet.Versions()[1500000000000].GetCardinality())
+	assert.True(t, idSet.Versions()[series.Version(1500000000000)].Contains(4))
 	// find not existed host
 	_, err = reader.FindSeriesIDsByExprForTagKeyID(22, &stmt.EqualsExpr{Key: "host", Value: "eleme-dev-sh-41"},
 		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
@@ -192,10 +194,10 @@ func Test_InvertedIndexReader_FindSeriesIDsByExprForTagID_InExpr(t *testing.T) {
 		Key: "host", Values: []string{"eleme-dev-sh-4", "eleme-dev-sh-5", "eleme-dev-sh-55"}},
 		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
 	assert.Nil(t, err)
-	assert.Contains(t, idSet.Versions(), series.Version(1500000000))
-	assert.Equal(t, uint64(2), idSet.Versions()[1500000000].GetCardinality())
-	assert.True(t, idSet.Versions()[series.Version(1500000000)].Contains(4))
-	assert.True(t, idSet.Versions()[series.Version(1500000000)].Contains(5))
+	assert.Contains(t, idSet.Versions(), series.Version(1500000000000))
+	assert.Equal(t, uint64(2), idSet.Versions()[1500000000000].GetCardinality())
+	assert.True(t, idSet.Versions()[series.Version(1500000000000)].Contains(4))
+	assert.True(t, idSet.Versions()[series.Version(1500000000000)].Contains(5))
 	// find not existed host
 	_, err = reader.FindSeriesIDsByExprForTagKeyID(22, &stmt.InExpr{
 		Key: "host", Values: []string{"eleme-dev-sh-55"}},
@@ -213,10 +215,10 @@ func Test_InvertedIndexReader_FindSeriesIDsByExprForTagID_LikeExpr(t *testing.T)
 		Key: "host", Value: "eleme-dev-sh-"},
 		timeutil.TimeRange{Start: 1500000000 * 1000, End: 1600000000 * 1000})
 	assert.Nil(t, err)
-	assert.Contains(t, idSet.Versions(), series.Version(1500000000))
-	assert.Equal(t, uint64(3), idSet.Versions()[series.Version(1500000000)].GetCardinality())
-	assert.Equal(t, uint32(4), idSet.Versions()[series.Version(1500000000)].Minimum())
-	assert.Equal(t, uint32(6), idSet.Versions()[series.Version(1500000000)].Maximum())
+	assert.Contains(t, idSet.Versions(), series.Version(1500000000000))
+	assert.Equal(t, uint64(3), idSet.Versions()[series.Version(1500000000000)].GetCardinality())
+	assert.Equal(t, uint32(4), idSet.Versions()[series.Version(1500000000000)].Minimum())
+	assert.Equal(t, uint32(6), idSet.Versions()[series.Version(1500000000000)].Maximum())
 	// find not existed host
 	_, err = reader.FindSeriesIDsByExprForTagKeyID(22, &stmt.InExpr{
 		Key: "host", Values: []string{"eleme-dev-sh---"}},
@@ -235,81 +237,62 @@ func Test_InvertedIndexReader_FindSeriesIDsByExprForTagID_RegexExpr(t *testing.T
 	assert.Nil(t, err)
 }
 
-func Test_InvertedIndexReader_entrySetBlockToIDSet_error_cases(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	reader := buildSeriesIndexReader(ctrl)
-	readerImpl := reader.(*invertedIndexReader)
+func Test_newTagKVEntrySet_error_cases(t *testing.T) {
 	// block length too short, 8 bytes
-	_, err := readerImpl.entrySetBlockToIDSet(
-		[]byte{16, 86, 104, 89, 32, 63, 84, 101},
-		timeutil.TimeRange{
-			Start: 1500000000 * 1000,
-			End:   1600000000 * 1000}, nil)
+	_, err := newTagKVEntrySet([]byte{16, 86, 104, 89, 32, 63, 84, 101})
 	assert.NotNil(t, err)
-	// read tagValue Count failed
-	_, err = readerImpl.entrySetBlockToIDSet(
-		[]byte{16, 86, 104, 89, 32, 63, 84, 101, 1, 1, 0},
-		timeutil.TimeRange{
-			Start: 1500000000 * 1000,
-			End:   1600000000 * 1000}, nil)
-	assert.NotNil(t, err)
-	// read dataLen failed
-	_, err = readerImpl.entrySetBlockToIDSet(
-		[]byte{16, 86, 104, 89, 32, 63, 84, 101, 1, 1, 1},
-		timeutil.TimeRange{
-			Start: 1500000000 * 1000,
-			End:   1600000000 * 1000}, nil)
-	assert.NotNil(t, err)
-	// offsets is nil
-	_, _, hostBlock := buildInvertedIndexBlock()
-	_, err = readerImpl.entrySetBlockToIDSet(
-		hostBlock,
-		timeutil.TimeRange{
-			Start: 1500000000 * 1000,
-			End:   1600000000 * 1000}, []int{10, 11, 12})
+	// validate offsets failure
+	_, err = newTagKVEntrySet([]byte{
+		1, 1, 1, 1,
+		2, 2, 2, 2,
+		3, 3, 3, 3,
+		4, 4, 4, 4,
+		5})
 	assert.NotNil(t, err)
 }
 
-func Test_InvertedIndexReader_readTagValueDataBlock_error_cases(t *testing.T) {
+func Test_InvertedIndexReader_entrySetToIDSet_error_cases(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	reader := buildSeriesIndexReader(ctrl)
 	readerImpl := reader.(*invertedIndexReader)
 
-	// validation of length failed
-	idSet, err := readerImpl.readTagValueDataBlock(nil, 10, timeutil.TimeRange{})
-	assert.NotNil(t, err)
+	zoneBlock, _, _ := buildInvertedIndexBlock()
+	zoneEntrySet, _ := newTagKVEntrySet(zoneBlock)
+	// first offset not exist
+	idSet, err := readerImpl.entrySetToIDSet(
+		zoneEntrySet,
+		timeutil.TimeRange{Start: 0, End: math.MaxInt64},
+		[]int{1000, 1200})
 	assert.Nil(t, idSet)
-
-	// read versionCount failed
-	_, err = readerImpl.readTagValueDataBlock([]byte{0}, 0, timeutil.TimeRange{})
 	assert.NotNil(t, err)
-
-	// read version block failed
-	_, err = readerImpl.readTagValueDataBlock([]byte{1, 0}, 0, timeutil.TimeRange{})
+	// last offset not exist
+	idSet, err = readerImpl.entrySetToIDSet(
+		zoneEntrySet,
+		timeutil.TimeRange{Start: 0, End: math.MaxInt64},
+		[]int{0, 1200})
+	assert.Nil(t, idSet)
 	assert.NotNil(t, err)
 }
 
-func Test_InvertedIndexReader_entrySetBlockToTreeQuerier_error_cases(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	reader := buildSeriesIndexReader(ctrl)
-	readerImpl := reader.(*invertedIndexReader)
+func Test_tagKVEntrySet_TrieTree_error_cases(t *testing.T) {
+	zoneBlock, _, _ := buildInvertedIndexBlock()
+	entrySet, _ := newTagKVEntrySet(zoneBlock)
 
 	// read stream eof
-	_, err := readerImpl.entrySetBlockToTreeQuerier(
-		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1})
+	entrySet.sr.Reset([]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1})
+	// read stream eof
+	_, err := entrySet.TrieTree()
 	assert.NotNil(t, err)
 
 	// failed validation of trie tree
-	_, err = readerImpl.entrySetBlockToTreeQuerier(
-		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1, 1, 1})
+	entrySet.sr.Reset([]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 1, 1, 1, 1, 1, 1})
+	_, err = entrySet.TrieTree()
 	assert.NotNil(t, err)
 
 	// LOUDS block unmarshal failed
-	_, err = readerImpl.entrySetBlockToTreeQuerier(
-		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 6, 1, 1, 1, 1, 1, 1})
+	entrySet.sr.Reset([]byte{1, 2, 3, 4, 5, 6, 7, 8, 6, 1, 1, 1, 1, 1, 1})
+	_, err = entrySet.TrieTree()
 	assert.NotNil(t, err)
 
 	// isPrefixKey block unmarshal failed
@@ -321,7 +304,14 @@ func Test_InvertedIndexReader_entrySetBlockToTreeQuerier_error_cases(t *testing.
 		13}) // louds
 
 	badBLOCK = append(badBLOCK, out...) // LOUDS block
-	_, err = readerImpl.entrySetBlockToTreeQuerier(badBLOCK)
+	entrySet.sr.Reset(badBLOCK)
+	_, err = entrySet.TrieTree()
+	assert.NotNil(t, err)
+}
+
+func Test_tagKVEntrySet_Bitmap(t *testing.T) {
+	data := versionedTagValueData{}
+	_, err := data.Bitmap()
 	assert.NotNil(t, err)
 }
 

--- a/tsdb/tblstore/metrics_meta_reader.go
+++ b/tsdb/tblstore/metrics_meta_reader.go
@@ -74,7 +74,7 @@ func (r *metricsMetaReader) readMetasBlock(
 	keyMetaLength := r.sr.ReadUvarint64()
 	startOfTagMeta := r.sr.Position()
 	// jump to end of tagMeta block
-	r.sr.ShiftAt(uint32(keyMetaLength))
+	_ = r.sr.ReadSlice(int(keyMetaLength))
 	endOfTagMeta := r.sr.Position()
 	// block size too small
 	if r.sr.Error() != nil {
@@ -84,7 +84,7 @@ func (r *metricsMetaReader) readMetasBlock(
 	// read length of fieldMeta
 	fieldMetaLen := r.sr.ReadUvarint64()
 	startOfFieldMeta := r.sr.Position()
-	r.sr.ShiftAt(uint32(fieldMetaLen))
+	_ = r.sr.ReadSlice(int(fieldMetaLen))
 	endOfFieldMeta := r.sr.Position()
 	// failing assertion: the remaining block is field block
 	if r.sr.Error() != nil || !r.sr.Empty() {
@@ -179,7 +179,7 @@ func (ti *tagKeyIDIterator) Next() (
 	tagKeyID uint32,
 ) {
 	tagKeyLen := ti.sr.ReadByte()
-	tagKey = string(ti.sr.ReadBytes(int(tagKeyLen)))
+	tagKey = string(ti.sr.ReadSlice(int(tagKeyLen)))
 	tagKeyID = ti.sr.ReadUint32()
 	return
 }
@@ -199,7 +199,7 @@ func (fi *fieldIDIterator) Next() (
 ) {
 	// read field-name
 	thisFieldNameLen := fi.sr.ReadByte()
-	fieldName = string(fi.sr.ReadBytes(int(thisFieldNameLen)))
+	fieldName = string(fi.sr.ReadSlice(int(thisFieldNameLen)))
 	// read field-type
 	fieldType = field.Type(fi.sr.ReadByte())
 	// read field-ID

--- a/tsdb/tblstore/metrics_nameid_merger.go
+++ b/tsdb/tblstore/metrics_nameid_merger.go
@@ -58,7 +58,7 @@ func (m *metricsNameIDMerger) Merge(key uint32, value [][]byte) ([]byte, error) 
 		for !m.sr.Empty() {
 			// read length of metricName
 			size := m.sr.ReadUvarint64()
-			metricName := m.sr.ReadBytes(int(size))
+			metricName := m.sr.ReadSlice(int(size))
 			metricID := m.sr.ReadUint32()
 			if m.sr.Error() != nil {
 				return nil, m.sr.Error()

--- a/tsdb/tblstore/metrics_nameid_reader.go
+++ b/tsdb/tblstore/metrics_nameid_reader.go
@@ -54,7 +54,7 @@ func (r *metricsNameIDReader) UnmarshalBinaryToART(
 	for !r.sr.Empty() {
 		// read length of metricName
 		size := r.sr.ReadUvarint64()
-		metricName := r.sr.ReadBytes(int(size))
+		metricName := r.sr.ReadSlice(int(size))
 		metricID := r.sr.ReadUint32()
 		if r.sr.Error() != nil {
 			return r.sr.Error()
@@ -119,10 +119,10 @@ func (r *metricsNameIDReader) ReadBlock(
 	if len(block) < metricNameIDSequenceSize {
 		return nil, 0, 0, false
 	}
-	idSequencePos := uint32(len(block) - metricNameIDSequenceSize)
+	idSequencePos := len(block) - metricNameIDSequenceSize
 	compressed = block[:idSequencePos]
 	r.sr.Reset(block)
-	r.sr.ShiftAt(idSequencePos)
+	_ = r.sr.ReadSlice(idSequencePos)
 
 	metricIDSeq = r.sr.ReadUint32()
 	tagKeyIDSeq = r.sr.ReadUint32()


### PR DESCRIPTION
- add merger for InvertedIndexTable;
- use `deltaBitPacking` offsets to record tagValueBlock's positions in InvertedIndexTable;
- add `stream.ReadSlice` for zero-copy reading and arbitrarily jump-reading;
- add `stream.SeekStart` to re-read the slice without calling `Reset`;
- add a reusable `TrieTreeIterator` for filtering and prefix-searching of the trie-tree;
- move `versionBlocksMap` of `forwardIndexMerger` from heap to stack;