### PR TITLE
[fix][tsdb]: simplify metric-store by lock-free atomic.Value

### DIFF
--- a/series/error.go
+++ b/series/error.go
@@ -20,3 +20,7 @@ var ErrTooManyFields = errors.New("too many fields")
 // ErrWrongFieldType is the error returned by tsdb when
 // field-type of new point is different from the type before.
 var ErrWrongFieldType = errors.New("field type is wrong")
+
+// ErrResetVersionUnavailable is the error returned by tsdb when
+// the immutable tagIndex has not been flushed yet.
+var ErrResetVersionUnavailable = errors.New("reset version unavailable")

--- a/tsdb/doc.go
+++ b/tsdb/doc.go
@@ -159,7 +159,7 @@ TagKeysBlock stores all tagKeys of the metric
 │  Time Range Block   ││                      TagKeys Block                   ││Dict Block││      Tags Blocks    │
 ├──────────┬──────────┤├──────────┬──────────┬──────────┬──────────┬──────────┤├──────────┤├──────────┬──────────┤
 │   Start  │   End    ││  TagKey  │  TagKey1 │  TagKey1 │  TagKey2 │  TagKey2 ││          ││TagsBlock1│TagsBlock2│
-│   Time   │   Time   ││  Count   │  Length  │          │  Length  │          ││  .....   ││          │          │
+│TimeDelta │TimeDelta ││  Count   │  Length  │          │  Length  │          ││  .....   ││          │          │
 ├──────────┼──────────┤├──────────┼──────────┼──────────┼──────────┼──────────┤├──────────┤├──────────┼──────────┤
 │  4 Bytes │  4 Bytes ││ uvariant │ uvariant │  N Bytes │ uvariant │  N Bytes ││  N Bytes ││  N Bytes │  N Bytes │
 └──────────┴──────────┘└──────────┴──────────┴──────────┴──────────┴──────────┘└──────────┘^──────────^──────────┘
@@ -247,9 +247,9 @@ This block is alias as TreeBlock
 │       TimeRange     │                        LOUDS Encoded Trie Tree                             │
 ├──────────┬──────────┼──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┤
 │ StartTime│  EndTime │   Trie   │  Labels  │  labels  │ isPrefix │ isPrefix │  LOUDS   │  LOUDS   │
-│  uint32  │  uint32  │  TreeLen │  Length  │  Block   │ Key Len  │Key BitMap│  Length  │  BitMap  │
+│   int64  │   int64  │  TreeLen │  Length  │  Block   │ Key Len  │Key BitMap│  Length  │  BitMap  │
 ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-│  4 Bytes │  4 Bytes │ uvariant │ uvariant │ N Bytes  │ uvariant │ N Bytes  │ uvariant │ N Bytes  │
+│  8 Bytes │  8 Bytes │ uvariant │ uvariant │ N Bytes  │ uvariant │ N Bytes  │ uvariant │ N Bytes  │
 └──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
 
 Level2(Versioned TagValue Data)

--- a/tsdb/memdb/constants.go
+++ b/tsdb/memdb/constants.go
@@ -1,28 +1,20 @@
 package memdb
 
-import "sync/atomic"
+import (
+	"time"
+
+	"go.uber.org/atomic"
+)
 
 const (
 	// buckets count for sharding metric-stores, 32
 	shardingCountOfMStores = 2 << 4
 	// mask for calculating sharding-index by AND
 	shardingCountMask = shardingCountOfMStores - 1
-	// unit: seconds, used to prevent resetting metric-store too frequently.
-	minIntervalForResetMetricStore = 10
 )
 
 // use var for mocking
 var (
-	// store will be purged if have not been used in this TTL, unit: milliseconds
-	tagsIDTTL int64 = 300 * 1000
+	// series will be purged if have not been used in this TTL
+	seriesTTL = atomic.NewDuration(5 * time.Minute)
 )
-
-// getTagsIDTTL returns the tagsIDTTL
-func getTagsIDTTL() int64 {
-	return atomic.LoadInt64(&tagsIDTTL)
-}
-
-// setTagsIDTTL sets the tagsIDTTL
-func setTagsIDTTL(ttl int64) {
-	atomic.StoreInt64(&tagsIDTTL, ttl)
-}

--- a/tsdb/memdb/database_test.go
+++ b/tsdb/memdb/database_test.go
@@ -53,9 +53,9 @@ func Test_MemoryDatabase_Write(t *testing.T) {
 
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().getMetricID().Return(uint32(1)).AnyTimes()
-	errCall1 := mockMStore.EXPECT().write(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
-	okCall2 := mockMStore.EXPECT().write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockMStore.EXPECT().GetMetricID().Return(uint32(1)).AnyTimes()
+	errCall1 := mockMStore.EXPECT().Write(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
+	okCall2 := mockMStore.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	gomock.InOrder(errCall1, okCall2)
 	// load mock
 	hash := fnv1a.HashString64("test1")
@@ -87,9 +87,9 @@ func Test_MemoryDatabase_setLimitations_countTags_countMetrics_resetMStore(t *te
 	assert.Equal(t, 0, md.CountMetrics())
 
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().setMaxTagsLimit(gomock.Any()).Return().AnyTimes()
-	mockMStore.EXPECT().getTagsUsed().Return(1).AnyTimes()
-	mockMStore.EXPECT().resetVersion().Return(nil).AnyTimes()
+	mockMStore.EXPECT().SetMaxTagsLimit(gomock.Any()).Return().AnyTimes()
+	mockMStore.EXPECT().GetTagsUsed().Return(1).AnyTimes()
+	mockMStore.EXPECT().ResetVersion().Return(nil).AnyTimes()
 	// setLimitations
 	limitations := map[string]uint32{"cpu.load": 10, "memory": 100}
 	hash := fnv1a.HashString64("cpu.load")
@@ -183,8 +183,8 @@ func Test_FindSeriesIDsByExpr_GetSeriesIDsForTag(t *testing.T) {
 	md := mdINTF.(*memoryDatabase)
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().findSeriesIDsByExpr(gomock.Any()).Return(nil, nil).AnyTimes()
-	mockMStore.EXPECT().getSeriesIDsForTag("").Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().FindSeriesIDsByExpr(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().GetSeriesIDsForTag("").Return(nil, nil).AnyTimes()
 	// not exist
 	_, err := md.FindSeriesIDsByExpr(1, nil, timeutil.TimeRange{})
 	assert.NotNil(t, err)
@@ -220,12 +220,12 @@ func Test_MemoryDatabase_flushFamilyTo_ok(t *testing.T) {
 	md := mdINTF.(*memoryDatabase)
 
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().getMetricID().Return(uint32(1)).AnyTimes()
-	mockMStore.EXPECT().evict().Return().AnyTimes()
-	mockMStore.EXPECT().isEmpty().Return(false).AnyTimes()
+	mockMStore.EXPECT().GetMetricID().Return(uint32(1)).AnyTimes()
+	mockMStore.EXPECT().Evict().Return().AnyTimes()
+	mockMStore.EXPECT().IsEmpty().Return(false).AnyTimes()
 
-	returnNil := mockMStore.EXPECT().flushMetricsTo(gomock.Any(), gomock.Any()).Return(nil)
-	returnError := mockMStore.EXPECT().flushMetricsTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
+	returnNil := mockMStore.EXPECT().FlushMetricsTo(gomock.Any(), gomock.Any()).Return(nil)
+	returnError := mockMStore.EXPECT().FlushMetricsTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
 	gomock.InOrder(returnNil, returnError)
 
 	md.getBucket(4).hash2MStore[1] = mockMStore
@@ -249,10 +249,10 @@ func Test_MemoryDatabase_flushIndexTo(t *testing.T) {
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
 	gomock.InOrder(
-		mockMStore.EXPECT().flushInvertedIndexTo(gomock.Any(), gomock.Any()).Return(nil),
-		mockMStore.EXPECT().flushInvertedIndexTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")),
-		mockMStore.EXPECT().flushForwardIndexTo(gomock.Any()).Return(nil),
-		mockMStore.EXPECT().flushForwardIndexTo(gomock.Any()).Return(fmt.Errorf("error")),
+		mockMStore.EXPECT().FlushInvertedIndexTo(gomock.Any(), gomock.Any()).Return(nil),
+		mockMStore.EXPECT().FlushInvertedIndexTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")),
+		mockMStore.EXPECT().FlushForwardIndexTo(gomock.Any()).Return(nil),
+		mockMStore.EXPECT().FlushForwardIndexTo(gomock.Any()).Return(fmt.Errorf("error")),
 	)
 	// insert to bucket
 	md.getBucket(4).hash2MStore[1] = mockMStore
@@ -273,7 +273,7 @@ func Test_MemoryDatabase_GetTagValues(t *testing.T) {
 	md := mdINTF.(*memoryDatabase)
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().getTagValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockMStore.EXPECT().GetTagValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	md.getBucket(3333).hash2MStore[3333] = mockMStore
 	md.metricID2Hash.Store(uint32(3333), uint64(3333))
 
@@ -300,8 +300,8 @@ func Test_MemoryDatabase_Suggset(t *testing.T) {
 
 	// mock mStore
 	mockMStore := NewMockmStoreINTF(ctrl)
-	mockMStore.EXPECT().suggestTagKeys(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	mockMStore.EXPECT().suggestTagValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockMStore.EXPECT().SuggestTagKeys(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockMStore.EXPECT().SuggestTagValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	md.getBucket(fnv1a.HashString64("test")).hash2MStore[fnv1a.HashString64("test")] = mockMStore
 
 	assert.Nil(t, md.SuggestTagKeys("test", "", 100))

--- a/tsdb/memdb/field_store_scan.go
+++ b/tsdb/memdb/field_store_scan.go
@@ -8,15 +8,21 @@ import (
 	"github.com/lindb/lindb/series/field"
 )
 
-// scan scans field store for given series id
-func (fs *fieldStore) scan(sCtx *series.ScanContext, version series.Version, seriesID uint32, fieldMeta *fieldMeta, ts *timeSeriesStore) {
+// Scan scans field store for given series id
+func (fs *fieldStore) Scan(
+	sCtx *series.ScanContext,
+	version series.Version,
+	seriesID uint32,
+	fieldMeta *fieldMeta,
+	ts *timeSeriesStore,
+) {
 	queryTimeRange := &sCtx.TimeRange
 	worker := sCtx.Worker
 	calc := sCtx.IntervalCalc
 	interval := sCtx.Interval
 	for _, fsStore := range fs.sStoreNodes {
 		// check family time is in query time range
-		familyTime := fsStore.getFamilyTime()
+		familyTime := fsStore.GetFamilyTime()
 		timeRange := &timeutil.TimeRange{
 			Start: familyTime,
 			End:   calc.CalcFamilyEndTime(familyTime),
@@ -48,7 +54,12 @@ type fStoreIterator struct {
 	idx int
 }
 
-func newFStoreIterator(familyStartTime int64, fieldMeta *fieldMeta, sStore sStoreINTF, ts *timeSeriesStore) *fStoreIterator {
+func newFStoreIterator(
+	familyStartTime int64,
+	fieldMeta *fieldMeta,
+	sStore sStoreINTF,
+	ts *timeSeriesStore,
+) *fStoreIterator {
 	return &fStoreIterator{
 		familyStartTime: familyStartTime,
 		sStore:          sStore,
@@ -69,7 +80,7 @@ func (fsi *fStoreIterator) HasNext() bool {
 	fsi.idx++
 
 	fsi.ts.sl.Lock()
-	data, _, _, err := fsi.sStore.bytes(false)
+	data, _, _, err := fsi.sStore.Bytes(false)
 	fsi.ts.sl.Unlock()
 
 	if err != nil {

--- a/tsdb/memdb/field_store_scan_test.go
+++ b/tsdb/memdb/field_store_scan_test.go
@@ -41,7 +41,7 @@ func TestFieldStore_Scan(t *testing.T) {
 	}, IntervalCalc: calc, Interval: 10000}
 	fieldMeta := &fieldMeta{fieldID: 1, fieldName: "f1", fieldType: field.SumField}
 	// no data
-	fStore.scan(sCtx, series.Version(10), uint32(10), fieldMeta, ts)
+	fStore.Scan(sCtx, series.Version(10), uint32(10), fieldMeta, ts)
 
 	// write data
 	fStore.Write(
@@ -59,7 +59,7 @@ func TestFieldStore_Scan(t *testing.T) {
 
 	// time range not match
 	now, _ = timeutil.ParseTimestamp("20190702 20:10:48", "20060102 15:04:05")
-	fStore.scan(&series.ScanContext{TimeRange: timeutil.TimeRange{
+	fStore.Scan(&series.ScanContext{TimeRange: timeutil.TimeRange{
 		Start: now - 100,
 		End:   now + 1000,
 	}, IntervalCalc: calc, Interval: 10000}, series.Version(10), uint32(10), fieldMeta, ts)
@@ -67,7 +67,7 @@ func TestFieldStore_Scan(t *testing.T) {
 	// found it
 	now, _ = timeutil.ParseTimestamp("20190702 19:10:48", "20060102 15:04:05")
 	worker := &mockScanWorker{}
-	fStore.scan(&series.ScanContext{
+	fStore.Scan(&series.ScanContext{
 		TimeRange: timeutil.TimeRange{
 			Start: now - 100,
 			End:   now + 1000,
@@ -112,7 +112,7 @@ func TestFieldStore_Scan(t *testing.T) {
 	// found it
 	now, _ = timeutil.ParseTimestamp("20190702 19:10:48", "20060102 15:04:05")
 	worker = &mockScanWorker{}
-	fStore.scan(&series.ScanContext{
+	fStore.Scan(&series.ScanContext{
 		TimeRange: timeutil.TimeRange{
 			Start: now - 100,
 			End:   now + 1000,

--- a/tsdb/memdb/field_store_test.go
+++ b/tsdb/memdb/field_store_test.go
@@ -13,7 +13,7 @@ import (
 
 func getMockSStore(ctrl *gomock.Controller, familyTime int64) *MocksStoreINTF {
 	mockSStore := NewMocksStoreINTF(ctrl)
-	mockSStore.EXPECT().getFamilyTime().Return(familyTime).AnyTimes()
+	mockSStore.EXPECT().GetFamilyTime().Return(familyTime).AnyTimes()
 	return mockSStore
 }
 
@@ -50,13 +50,13 @@ func Test_fStore_timeRange(t *testing.T) {
 	theFieldStore := fStore.(*fieldStore)
 
 	mockSStore1 := getMockSStore(ctrl, 1564300800000)
-	mockSStore1.EXPECT().slotRange().Return(1, 10, nil).AnyTimes()
+	mockSStore1.EXPECT().SlotRange().Return(1, 10, nil).AnyTimes()
 	mockSStore2 := getMockSStore(ctrl, 1564304400000)
-	mockSStore2.EXPECT().slotRange().Return(3, 5, nil).AnyTimes()
+	mockSStore2.EXPECT().SlotRange().Return(3, 5, nil).AnyTimes()
 	mockSStore3 := getMockSStore(ctrl, 1564297200000)
-	mockSStore3.EXPECT().slotRange().Return(6, 13, fmt.Errorf("error")).AnyTimes()
+	mockSStore3.EXPECT().SlotRange().Return(6, 13, fmt.Errorf("error")).AnyTimes()
 	mockSStore4 := getMockSStore(ctrl, 1564308000000)
-	mockSStore4.EXPECT().slotRange().Return(4, 14, nil).AnyTimes()
+	mockSStore4.EXPECT().SlotRange().Return(4, 14, nil).AnyTimes()
 
 	// error case
 
@@ -89,9 +89,9 @@ func Test_fStore_flushFieldTo(t *testing.T) {
 
 	mockTF := makeMockDataFlusher(ctrl)
 	mockSStore1 := getMockSStore(ctrl, 1564304400000)
-	mockSStore1.EXPECT().bytes(true).Return(nil, 0, 0, fmt.Errorf("error")).AnyTimes()
+	mockSStore1.EXPECT().Bytes(true).Return(nil, 0, 0, fmt.Errorf("error")).AnyTimes()
 	mockSStore2 := getMockSStore(ctrl, 1564308000000)
-	mockSStore2.EXPECT().bytes(true).Return(nil, 1, 212, nil).AnyTimes()
+	mockSStore2.EXPECT().Bytes(true).Return(nil, 1, 212, nil).AnyTimes()
 
 	theFieldStore.insertSStore(mockSStore1)
 	theFieldStore.insertSStore(mockSStore2)

--- a/tsdb/memdb/metric_store_index.go
+++ b/tsdb/memdb/metric_store_index.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync/atomic"
 
 	"github.com/lindb/lindb/constants"
 	"github.com/lindb/lindb/models"
@@ -15,43 +14,58 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/segmentio/fasthash/fnv1a"
+	"go.uber.org/atomic"
 )
 
 //go:generate mockgen -source ./metric_store_index.go -destination=./metric_store_index_mock_test.go -package memdb
 
 // tagIndexINTF abstracts the index of tStores, not thread-safe
 type tagIndexINTF interface {
-	// updateTime updates the start and endTime by CAS
-	updateTime(pointTime uint32)
-	// return timeRange in seconds
-	getTimeRange() (startTime, endTime uint32)
-	// getTagKVEntrySet returns the kv-entrySet by tagKey
-	getTagKVEntrySet(tagKey string) (*tagKVEntrySet, bool)
-	// getTagKVEntrySets returns the kv-entrySets for flushing index data.
-	getTagKVEntrySets() []tagKVEntrySet
-	// getTStore get tStore from map tags
-	getTStore(tags map[string]string) (tStoreINTF, bool)
-	// getTStoreBySeriesID get tStore from seriesID
-	getTStoreBySeriesID(seriesID uint32) (tStoreINTF, bool)
-	// getOrCreateTStore constructs the index and return a tStore,
+	// UpdateIndexTimeRange updates the start and endTime by CAS
+	UpdateIndexTimeRange(pointTime int64)
+
+	// IndexTimeRange returns the time range of index
+	IndexTimeRange() timeutil.TimeRange
+
+	// GetTagKVEntrySet returns the kv-entrySet by tagKey
+	GetTagKVEntrySet(tagKey string) (*tagKVEntrySet, bool)
+
+	// GetTagKVEntrySets returns the kv-entrySets for flushing index data.
+	GetTagKVEntrySets() []tagKVEntrySet
+
+	// GetTStore get tStore from map tags
+	GetTStore(tags map[string]string) (tStoreINTF, bool)
+
+	// GetTStoreBySeriesID get tStore from seriesID
+	GetTStoreBySeriesID(seriesID uint32) (tStoreINTF, bool)
+
+	// GetOrCreateTStore constructs the index and return a tStore,
 	// error of too may tag keys may be return
-	getOrCreateTStore(tags map[string]string) (tStoreINTF, error)
-	// removeTStores removes tStores from a list of seriesID
-	removeTStores(seriesIDs ...uint32)
-	// tagsUsed returns the count of all used tags, it is used for restricting write.
-	tagsUsed() int
-	// tagsInUse returns how many tags are still in use, it is used for evicting
-	tagsInUse() int
-	// allTStores returns the map of seriesID and tStores
-	allTStores() map[uint32]tStoreINTF
-	// flushMetricTo flush metric to the tableFlusher
-	flushMetricTo(flusher tblstore.MetricsDataFlusher, flushCtx flushContext) error
-	// getVersion returns a version(uptime in milliseconds) of the index
-	getVersion() series.Version
-	// findSeriesIDsByExpr finds series ids by tag filter expr
-	findSeriesIDsByExpr(expr stmt.TagFilter) *roaring.Bitmap
-	// getSeriesIDsForTag get series ids by tagKey
-	getSeriesIDsForTag(tagKey string) *roaring.Bitmap
+	GetOrCreateTStore(tags map[string]string) (tStoreINTF, error)
+
+	// RemoveTStores removes tStores from a list of seriesID
+	RemoveTStores(seriesIDs ...uint32)
+
+	// TagsUsed returns the count of all used tags, it is used for restricting write.
+	TagsUsed() int
+
+	// TagsInUse returns how many tags are still in use, it is used for evicting
+	TagsInUse() int
+
+	// AllTStores returns the map of seriesID and tStores
+	AllTStores() map[uint32]tStoreINTF
+
+	// FlushMetricTo flush metric to the tableFlusher
+	FlushMetricTo(flusher tblstore.MetricsDataFlusher, flushCtx flushContext) error
+
+	// Version returns a version(uptime in milliseconds) of the index
+	Version() series.Version
+
+	// FindSeriesIDsByExpr finds series ids by tag filter expr
+	FindSeriesIDsByExpr(expr stmt.TagFilter) *roaring.Bitmap
+
+	// GetSeriesIDsForTag get series ids by tagKey
+	GetSeriesIDsForTag(tagKey string) *roaring.Bitmap
 }
 
 // tagKVEntrySet is a inverted mapping relation of tag-value and seriesID group.
@@ -78,52 +92,59 @@ type tagIndex struct {
 	// forwardIndex for storing a mapping from tag-hash to the seriesID,
 	// purpose of this index is used for fast writing
 	hash2SeriesID map[uint64]uint32
-	idCounter     uint32
+	idCounter     atomic.Uint32
 	// version is the uptime in millseconds
-	version   series.Version
-	startTime uint32 // startTime, endTime of all data written
-	endTime   uint32
+	version series.Version
+	// index time-range
+	earliestTimeDelta atomic.Int32 // earliestTime = versionTime + earliestTimeDelta
+	latestTimeDelta   atomic.Int32 // latestTime = versionTime + latestTimeDelta
 }
 
 // newTagIndex returns a new tagIndexINTF with version.
 func newTagIndex() tagIndexINTF {
 	return &tagIndex{
-		seriesID2TStore: make(map[uint32]tStoreINTF),
-		hash2SeriesID:   make(map[uint64]uint32),
-		version:         series.NewVersion(),
-		startTime:       uint32(timeutil.Now() / 1000),
-		endTime:         uint32(timeutil.Now() / 1000)}
+		seriesID2TStore:   make(map[uint32]tStoreINTF),
+		hash2SeriesID:     make(map[uint64]uint32),
+		version:           series.NewVersion(),
+		idCounter:         *atomic.NewUint32(0), // first value is 1
+		earliestTimeDelta: *atomic.NewInt32(0),
+		latestTimeDelta:   *atomic.NewInt32(0)}
 }
 
-// updateTime updates the start and endTime by CAS
-func (index *tagIndex) updateTime(pointTime uint32) {
+// UpdateIndexTimeRange updates the start and endTime by CAS
+// lock-free
+func (index *tagIndex) UpdateIndexTimeRange(pointTime int64) {
+	timeDelta := int32((pointTime - index.version.Int64()) / 1000)
 	for {
-		startTime := atomic.LoadUint32(&index.startTime)
-		if startTime <= pointTime {
+		oldStartTimeDelta := index.earliestTimeDelta.Load()
+		if oldStartTimeDelta <= timeDelta {
 			break
 		}
-		if atomic.CompareAndSwapUint32(&index.startTime, startTime, pointTime) {
+		if index.earliestTimeDelta.CAS(oldStartTimeDelta, timeDelta) {
 			break
 		}
 	}
 	for {
-		endTime := atomic.LoadUint32(&index.endTime)
-		if endTime >= pointTime {
+		oldEndTimeDelta := index.latestTimeDelta.Load()
+		if oldEndTimeDelta >= timeDelta {
 			break
 		}
-		if atomic.CompareAndSwapUint32(&index.endTime, endTime, pointTime) {
+		if index.latestTimeDelta.CAS(oldEndTimeDelta, timeDelta) {
 			break
 		}
 	}
 }
 
-// getTimeRange return timeRange in seconds
-func (index *tagIndex) getTimeRange() (startTime, endTime uint32) {
-	return atomic.LoadUint32(&index.startTime), atomic.LoadUint32(&index.endTime)
+// lock-free
+func (index *tagIndex) IndexTimeRange() timeutil.TimeRange {
+	startTimeDelta, endTimeDelta := index.earliestTimeDelta.Load(), index.latestTimeDelta.Load()
+	return timeutil.TimeRange{
+		Start: index.version.Int64() + int64(startTimeDelta)*1000,
+		End:   index.version.Int64() + int64(endTimeDelta)*1000}
 }
 
-// getTagKVEntrySets returns the kv-entrySet for flushing index data.
-func (index *tagIndex) getTagKVEntrySets() []tagKVEntrySet {
+// GetTagKVEntrySets returns the kv-entrySet for flushing index data.
+func (index *tagIndex) GetTagKVEntrySets() []tagKVEntrySet {
 	return index.tagKVEntrySet
 }
 
@@ -153,8 +174,8 @@ func (index *tagIndex) insertNewTStore(tags map[string]string, newSeriesID uint3
 	return nil
 }
 
-// getTagKVEntrySet search the tagKeyEntry by binary-search
-func (index *tagIndex) getTagKVEntrySet(tagKey string) (*tagKVEntrySet, bool) {
+// GetTagKVEntrySet search the tagKeyEntry by binary-search
+func (index *tagIndex) GetTagKVEntrySet(tagKey string) (*tagKVEntrySet, bool) {
 	offset := sort.Search(len(index.tagKVEntrySet), func(i int) bool { return index.tagKVEntrySet[i].key >= tagKey })
 	// not present in the slice
 	if offset >= len(index.tagKVEntrySet) || index.tagKVEntrySet[offset].key != tagKey {
@@ -186,8 +207,8 @@ func (index *tagIndex) getOrInsertTagKeyEntry(tagKey string) (*tagKVEntrySet, er
 	return &newEntry, nil
 }
 
-// getTStore returns a tStoreINTF from map tags.
-func (index *tagIndex) getTStore(tags map[string]string) (tStoreINTF, bool) {
+// GetTStore returns a tStoreINTF from map tags.
+func (index *tagIndex) GetTStore(tags map[string]string) (tStoreINTF, bool) {
 	hash := fnv1a.HashString64(models.TagsAsString(tags))
 	seriesID, ok := index.hash2SeriesID[hash]
 	if ok {
@@ -196,15 +217,15 @@ func (index *tagIndex) getTStore(tags map[string]string) (tStoreINTF, bool) {
 	return nil, false
 }
 
-// getTStoreBySeriesID returns a tStoreINTF from series-id.
-func (index *tagIndex) getTStoreBySeriesID(seriesID uint32) (tStoreINTF, bool) {
+// GetTStoreBySeriesID returns a tStoreINTF from series-id.
+func (index *tagIndex) GetTStoreBySeriesID(seriesID uint32) (tStoreINTF, bool) {
 	tStore, ok := index.seriesID2TStore[seriesID]
 	return tStore, ok
 }
 
-// getOrCreateTStore get or creates the tStore from string tags,
+// GetOrCreateTStore get or creates the tStore from string tags,
 // the tags is considered as a empty key-value pair while tags is nil.
-func (index *tagIndex) getOrCreateTStore(tags map[string]string) (tStoreINTF, error) {
+func (index *tagIndex) GetOrCreateTStore(tags map[string]string) (tStoreINTF, error) {
 	tagsStr := models.TagsAsString(tags)
 	hash := fnv1a.HashString64(tagsStr)
 	seriesID, ok := index.hash2SeriesID[hash]
@@ -219,12 +240,12 @@ func (index *tagIndex) getOrCreateTStore(tags map[string]string) (tStoreINTF, er
 		return tStore, nil
 	}
 	// seriesID is not allocated before, assign a new one.
-	incrSeriesID := atomic.AddUint32(&index.idCounter, 1)
+	incrSeriesID := index.idCounter.Add(1)
 	newTStore := newTimeSeriesStore(hash)
 	// bind relation of tag kv pairs to the tStore
 	err := index.insertNewTStore(tags, incrSeriesID, newTStore)
 	if err != nil {
-		index.idCounter--
+		index.idCounter.Sub(1)
 		return nil, err
 	}
 	// bind relation of hash and seriesID to the forward index
@@ -232,9 +253,9 @@ func (index *tagIndex) getOrCreateTStore(tags map[string]string) (tStoreINTF, er
 	return newTStore, nil
 }
 
-// removeTStores removes the tStores from seriesIDs
-// removeTStores does not remove the mapping relation of hash and seriesID and keep the seriesID in bitmap
-func (index *tagIndex) removeTStores(seriesIDs ...uint32) {
+// RemoveTStores removes the tStores from seriesIDs
+// RemoveTStores does not remove the mapping relation of hash and seriesID and keep the seriesID in bitmap
+func (index *tagIndex) RemoveTStores(seriesIDs ...uint32) {
 	if len(seriesIDs) == 0 {
 		return
 	}
@@ -244,26 +265,26 @@ func (index *tagIndex) removeTStores(seriesIDs ...uint32) {
 	}
 }
 
-// tagsUsed returns the count of all used tStores
-func (index *tagIndex) tagsUsed() int {
+// TagsUsed returns the count of all used tStores
+func (index *tagIndex) TagsUsed() int {
 	return len(index.hash2SeriesID)
 }
 
-// tagsInUse returns how many tags are still in use, it is used for evicting
-func (index *tagIndex) tagsInUse() int {
+// TagsInUse returns how many tags are still in use, it is used for evicting
+func (index *tagIndex) TagsInUse() int {
 	return len(index.seriesID2TStore)
 }
 
-// allTStores returns the map of seriesID and tStores
-func (index *tagIndex) allTStores() map[uint32]tStoreINTF {
+// AllTStores returns the map of seriesID and tStores
+func (index *tagIndex) AllTStores() map[uint32]tStoreINTF {
 	return index.seriesID2TStore
 }
 
-// flushMetricTo flushes metric-block of mStore to the writer.
-func (index *tagIndex) flushMetricTo(tableFlusher tblstore.MetricsDataFlusher, flushCtx flushContext) error {
+// FlushMetricTo flushes metric-block of mStore to the writer.
+func (index *tagIndex) FlushMetricTo(tableFlusher tblstore.MetricsDataFlusher, flushCtx flushContext) error {
 	flushed := false
 	for seriesID, tStore := range index.seriesID2TStore {
-		tStoreDataFlushed := tStore.flushSeriesTo(tableFlusher, flushCtx, seriesID)
+		tStoreDataFlushed := tStore.FlushSeriesTo(tableFlusher, flushCtx, seriesID)
 		flushed = flushed || tStoreDataFlushed
 	}
 	if !flushed {
@@ -272,14 +293,14 @@ func (index *tagIndex) flushMetricTo(tableFlusher tblstore.MetricsDataFlusher, f
 	return tableFlusher.FlushMetric(flushCtx.metricID)
 }
 
-// getVersion returns a version(uptime) of the index
-func (index *tagIndex) getVersion() series.Version {
+// Version returns a version(uptime) of the index
+func (index *tagIndex) Version() series.Version {
 	return index.version
 }
 
-// findSeriesIDsByExpr finds series ids by tag filter expr
-func (index *tagIndex) findSeriesIDsByExpr(expr stmt.TagFilter) *roaring.Bitmap {
-	entrySet, ok := index.getTagKVEntrySet(expr.TagKey())
+// FindSeriesIDsByExpr finds series ids by tag filter expr
+func (index *tagIndex) FindSeriesIDsByExpr(expr stmt.TagFilter) *roaring.Bitmap {
+	entrySet, ok := index.GetTagKVEntrySet(expr.TagKey())
 	if !ok {
 		return nil
 	}
@@ -344,9 +365,9 @@ func (index *tagIndex) findSeriesIDsByRegex(entrySet *tagKVEntrySet, expr *stmt.
 	return union
 }
 
-// getSeriesIDsForTag get series ids by tagKey
-func (index *tagIndex) getSeriesIDsForTag(tagKey string) *roaring.Bitmap {
-	entrySet, ok := index.getTagKVEntrySet(tagKey)
+// GetSeriesIDsForTag get series ids by tagKey
+func (index *tagIndex) GetSeriesIDsForTag(tagKey string) *roaring.Bitmap {
+	entrySet, ok := index.GetTagKVEntrySet(tagKey)
 	if !ok {
 		return nil
 	}
@@ -355,4 +376,14 @@ func (index *tagIndex) getSeriesIDsForTag(tagKey string) *roaring.Bitmap {
 		union.Or(bitMap)
 	}
 	return union
+}
+
+// staticNopTagIndex is the static nop-tagIndex,
+// it is used as a placeholder of immutable atomic.Value
+var staticNopTagIndex = newNopTagIndex()
+
+func newNopTagIndex() tagIndexINTF {
+	ti := newTagIndex().(*tagIndex)
+	ti.version = 0
+	return ti
 }

--- a/tsdb/memdb/metric_store_index_test.go
+++ b/tsdb/memdb/metric_store_index_test.go
@@ -17,37 +17,37 @@ func Test_tagIndex_tStore_get(t *testing.T) {
 	tagIdxInterface := newTagIndex()
 	tagIdx := tagIdxInterface.(*tagIndex)
 	// version
-	assert.NotZero(t, tagIdxInterface.getVersion())
+	assert.NotZero(t, tagIdxInterface.Version())
 
 	// get empty key value tStore
-	tStore0, err := tagIdxInterface.getOrCreateTStore(nil)
+	tStore0, err := tagIdxInterface.GetOrCreateTStore(nil)
 	assert.NotNil(t, tStore0)
 	assert.Nil(t, err)
 	// get not exist tStore
-	tStore1, ok := tagIdxInterface.getTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
+	tStore1, ok := tagIdxInterface.GetTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
 	assert.Nil(t, tStore1)
 	assert.False(t, ok)
 	// get or create
-	tStore2, err := tagIdxInterface.getOrCreateTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
+	tStore2, err := tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
 	assert.NotNil(t, tStore2)
 	assert.Nil(t, err)
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
 	// get existed
-	tStore3, ok := tagIdxInterface.getTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
+	tStore3, ok := tagIdxInterface.GetTStore(map[string]string{"host": "adca", "ip": "1.1.1.1"})
 	assert.NotNil(t, tStore3)
 	assert.True(t, ok)
 	// get tStore by seriesID
 	assert.NotZero(t, len(tagIdx.seriesID2TStore))
-	tStore4, ok := tagIdxInterface.getTStoreBySeriesID(1)
+	tStore4, ok := tagIdxInterface.GetTStoreBySeriesID(1)
 	assert.NotNil(t, tStore4)
 	assert.True(t, ok)
 	// getOrInsertTagKeyEntry, present in the slice
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"g": "32"})
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"g": "33"})
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"h": "32"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"g": "32"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"g": "33"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"h": "32"})
 
 	// getTagKVEntrySet test
-	assert.NotNil(t, tagIdxInterface.getTagKVEntrySets())
+	assert.NotNil(t, tagIdxInterface.GetTagKVEntrySets())
 }
 
 func Test_tagIndex_tStore_error(t *testing.T) {
@@ -55,21 +55,21 @@ func Test_tagIndex_tStore_error(t *testing.T) {
 	tagIdx := tagIdxInterface.(*tagIndex)
 	// too many tag keys
 	for i := 0; i < 1000; i++ {
-		_, _ = tagIdx.getOrCreateTStore(map[string]string{strconv.Itoa(i): strconv.Itoa(i)})
+		_, _ = tagIdx.GetOrCreateTStore(map[string]string{strconv.Itoa(i): strconv.Itoa(i)})
 	}
-	assert.Equal(t, 512, tagIdx.tagsUsed())
-	_, err := tagIdxInterface.getOrCreateTStore(map[string]string{"zone": "nj"})
+	assert.Equal(t, 512, tagIdx.TagsUsed())
+	_, err := tagIdxInterface.GetOrCreateTStore(map[string]string{"zone": "nj"})
 	assert.Equal(t, series.ErrTooManyTagKeys, err)
-	assert.Equal(t, 512, tagIdx.tagsUsed())
+	assert.Equal(t, 512, tagIdx.TagsUsed())
 	// remove tStores
-	tagIdx.removeTStores()
-	tagIdx.removeTStores(1, 2, 3, 4, 1003)
+	tagIdx.RemoveTStores()
+	tagIdx.RemoveTStores(1, 2, 3, 4, 1003)
 	// used tags won't change
-	assert.Equal(t, 512, tagIdx.tagsUsed())
+	assert.Equal(t, 512, tagIdx.TagsUsed())
 	// in use tags was removed
-	assert.Equal(t, 508, tagIdx.tagsInUse())
+	assert.Equal(t, 508, tagIdx.TagsInUse())
 	// allTStores
-	assert.NotNil(t, tagIdxInterface.allTStores())
+	assert.NotNil(t, tagIdxInterface.AllTStores())
 }
 
 func Test_tagIndex_flushMetricTo(t *testing.T) {
@@ -83,40 +83,40 @@ func Test_tagIndex_flushMetricTo(t *testing.T) {
 	mockTF.EXPECT().FlushMetric(gomock.Any()).Return(nil).MaxTimes(2)
 
 	// tStores is empty
-	assert.Nil(t, tagIdxInterface.flushMetricTo(mockTF, flushContext{}))
+	assert.Nil(t, tagIdxInterface.FlushMetricTo(mockTF, flushContext{}))
 
 	// tStore is not empty
 	mockTStore1 := NewMocktStoreINTF(ctrl)
-	mockTStore1.EXPECT().getHash().Return(uint64(1)).AnyTimes()
-	mockTStore1.EXPECT().flushSeriesTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+	mockTStore1.EXPECT().GetHash().Return(uint64(1)).AnyTimes()
+	mockTStore1.EXPECT().FlushSeriesTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(false).AnyTimes()
 	mockTStore2 := NewMocktStoreINTF(ctrl)
-	mockTStore2.EXPECT().flushSeriesTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	mockTStore1.EXPECT().getHash().Return(uint64(2)).AnyTimes()
+	mockTStore2.EXPECT().FlushSeriesTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	mockTStore1.EXPECT().GetHash().Return(uint64(2)).AnyTimes()
 	tagIdx.seriesID2TStore = map[uint32]tStoreINTF{
 		1: mockTStore1,
 		2: mockTStore2,
 	}
 	// FlushMetric ok
-	assert.Nil(t, tagIdxInterface.flushMetricTo(mockTF, flushContext{}))
+	assert.Nil(t, tagIdxInterface.FlushMetricTo(mockTF, flushContext{}))
 }
 
 func prepareTagIdx(ctrl *gomock.Controller) tagIndexINTF {
 	tagIdxInterface := newTagIndex()
 	tagIdx := tagIdxInterface.(*tagIndex)
 
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "a", "zone": "nj"})   // seriesID: 1
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "abc", "zone": "sh"}) // 2
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "b", "zone": "nj"})   // 3
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "c", "zone": "bj"})   // 4
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "bc", "zone": "sz"})  // 5
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "b21", "zone": "nj"}) // 6
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "b22", "zone": "sz"}) // 7
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "bcd", "zone": "sh"}) // 8
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "a", "zone": "nj"})   // seriesID: 1
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "abc", "zone": "sh"}) // 2
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "b", "zone": "nj"})   // 3
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "c", "zone": "bj"})   // 4
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "bc", "zone": "sz"})  // 5
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "b21", "zone": "nj"}) // 6
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "b22", "zone": "sz"}) // 7
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "bcd", "zone": "sh"}) // 8
 
 	newMap := make(map[uint32]tStoreINTF)
 	for seriesID, tStore := range tagIdx.seriesID2TStore {
 		mockTStore := NewMocktStoreINTF(ctrl)
-		mockTStore.EXPECT().getHash().Return(tStore.getHash()).AnyTimes()
+		mockTStore.EXPECT().GetHash().Return(tStore.GetHash()).AnyTimes()
 		newMap[seriesID] = mockTStore
 	}
 
@@ -130,17 +130,17 @@ func Test_tagIndex_findSeriesIDsByEqual(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// tag-key not exist
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "not-exist-key", Value: "alpha"})
+	bitmap := tagIdxInterface.FindSeriesIDsByExpr(&stmt.EqualsExpr{Key: "not-exist-key", Value: "alpha"})
 	assert.Nil(t, bitmap)
 	// tag-value not exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "alpha"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "alpha"})
 	assert.Nil(t, bitmap)
 	// tag-value exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "c"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "c"})
 	assert.NotNil(t, bitmap)
 	assert.Equal(t, uint64(1), bitmap.GetCardinality())
 	// tag-value exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "bc"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.EqualsExpr{Key: "host", Value: "bc"})
 	assert.Equal(t, uint64(1), bitmap.GetCardinality())
 }
 
@@ -150,7 +150,7 @@ func Test_tagIndex_findSeriesIDsByIn(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// tag-value exist
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.InExpr{Key: "host", Values: []string{"b", "bc", "bcd", "ahi"}})
+	bitmap := tagIdxInterface.FindSeriesIDsByExpr(&stmt.InExpr{Key: "host", Values: []string{"b", "bc", "bcd", "ahi"}})
 	assert.Equal(t, uint64(3), bitmap.GetCardinality())
 }
 
@@ -160,12 +160,12 @@ func Test_tagIndex_findSeriesIDsByLike(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// tag-value exist
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "host", Value: "bc"})
+	bitmap := tagIdxInterface.FindSeriesIDsByExpr(&stmt.LikeExpr{Key: "host", Value: "bc"})
 	assert.Equal(t, uint64(3), bitmap.GetCardinality())
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "s"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "s"})
 	assert.Equal(t, uint64(4), bitmap.GetCardinality())
 	// tag-value not exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "not-exist"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.LikeExpr{Key: "zone", Value: "not-exist"})
 	assert.Zero(t, bitmap.GetCardinality())
 }
 
@@ -175,16 +175,16 @@ func Test_tagIndex_findSeriesIDsByRegex(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// pattern not match
-	bitmap := tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "bbbbbbbbbbb"})
+	bitmap := tagIdxInterface.FindSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "bbbbbbbbbbb"})
 	assert.Zero(t, bitmap.GetCardinality())
 	// pattern error
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "b.32*++++\n"})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: "b.32*++++\n"})
 	assert.Nil(t, bitmap)
 	// tag-value exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `b2[0-9]+`})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `b2[0-9]+`})
 	assert.Equal(t, uint64(2), bitmap.GetCardinality())
 	// literal prefix:22 not exist
-	bitmap = tagIdxInterface.findSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `22+`})
+	bitmap = tagIdxInterface.FindSeriesIDsByExpr(&stmt.RegexExpr{Key: "host", Regexp: `22+`})
 	assert.Equal(t, uint64(0), bitmap.GetCardinality())
 
 }
@@ -195,10 +195,10 @@ func Test_tagIndex_getSeriesIDsForTag(t *testing.T) {
 	tagIdxInterface := prepareTagIdx(ctrl)
 
 	// not-exist
-	bitmap := tagIdxInterface.getSeriesIDsForTag("not-exist-key")
+	bitmap := tagIdxInterface.GetSeriesIDsForTag("not-exist-key")
 	assert.Nil(t, bitmap)
 	// overlap
-	bitmap = tagIdxInterface.getSeriesIDsForTag("host")
+	bitmap = tagIdxInterface.GetSeriesIDsForTag("host")
 	assert.Equal(t, uint64(8), bitmap.GetCardinality())
 }
 
@@ -214,35 +214,35 @@ func Test_tagIndex_special_case(t *testing.T) {
 	defer ctrl.Finish()
 	tagIdxInterface := prepareTagIdx(ctrl)
 	// test expr type assertion failure
-	assert.Nil(t, tagIdxInterface.findSeriesIDsByExpr(mockTagKey{}))
+	assert.Nil(t, tagIdxInterface.FindSeriesIDsByExpr(mockTagKey{}))
 }
 
 func Test_TagIndex_recreateEvictedTStores(t *testing.T) {
 	tagIdxInterface := newTagIndex()
 
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "a"})
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "a"})
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "b"})
-	assert.Equal(t, 2, tagIdxInterface.tagsInUse())
-	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "a"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "a"})
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "b"})
+	assert.Equal(t, 2, tagIdxInterface.TagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.TagsUsed())
 	// remove seriesID = 1
-	tagIdxInterface.removeTStores(0, 1)
-	assert.Equal(t, 1, tagIdxInterface.tagsInUse())
-	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
-	_, _ = tagIdxInterface.getOrCreateTStore(map[string]string{"host": "a"})
-	assert.Equal(t, 2, tagIdxInterface.tagsInUse())
-	tagIdxInterface.removeTStores(1, 2)
-	assert.Equal(t, 0, tagIdxInterface.tagsInUse())
-	assert.Equal(t, 2, tagIdxInterface.tagsUsed())
+	tagIdxInterface.RemoveTStores(0, 1)
+	assert.Equal(t, 1, tagIdxInterface.TagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.TagsUsed())
+	_, _ = tagIdxInterface.GetOrCreateTStore(map[string]string{"host": "a"})
+	assert.Equal(t, 2, tagIdxInterface.TagsInUse())
+	tagIdxInterface.RemoveTStores(1, 2)
+	assert.Equal(t, 0, tagIdxInterface.TagsInUse())
+	assert.Equal(t, 2, tagIdxInterface.TagsUsed())
 }
 
 func Test_TagIndex_timeRange(t *testing.T) {
 	tagIdxInterface := newTagIndex()
-	startTime, endTime := tagIdxInterface.getTimeRange()
-	tagIdxInterface.updateTime(uint32(timeutil.Now()/1000 - 10))
-	tagIdxInterface.updateTime(uint32(timeutil.Now()/1000 + 10))
+	timeRange := tagIdxInterface.IndexTimeRange()
+	tagIdxInterface.UpdateIndexTimeRange(timeutil.Now() - 10*1000)
+	tagIdxInterface.UpdateIndexTimeRange(timeutil.Now() + 10*1000)
 
-	newStartTime, newEndTime := tagIdxInterface.getTimeRange()
-	assert.True(t, newStartTime < startTime)
-	assert.True(t, newEndTime > endTime)
+	newTimeRange := tagIdxInterface.IndexTimeRange()
+	assert.True(t, newTimeRange.Start < timeRange.Start)
+	assert.True(t, newTimeRange.End > timeRange.End)
 }

--- a/tsdb/memdb/metric_store_test.go
+++ b/tsdb/memdb/metric_store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lindb/lindb/pkg/timeutil"
 	pb "github.com/lindb/lindb/rpc/proto/field"
 	"github.com/lindb/lindb/series"
 	"github.com/lindb/lindb/series/field"
@@ -15,16 +16,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_mStore_getMetricId(t *testing.T) {
+func Test_mStore_GetMetricID(t *testing.T) {
 	mStoreInterface := newMetricStore(100)
 	mStore := mStoreInterface.(*metricStore)
 
 	assert.NotNil(t, mStoreInterface)
-	assert.Equal(t, uint32(100), mStoreInterface.getMetricID())
-	assert.True(t, mStoreInterface.isEmpty())
+	assert.Equal(t, uint32(100), mStoreInterface.GetMetricID())
+	assert.True(t, mStoreInterface.IsEmpty())
 	assert.False(t, mStore.isFull())
-	assert.Zero(t, mStoreInterface.getTagsUsed())
-	assert.Zero(t, mStoreInterface.getTagsInUse())
+	assert.Zero(t, mStoreInterface.GetTagsUsed())
+	assert.Zero(t, mStoreInterface.GetTagsInUse())
 }
 
 func Test_mStore_setMaxTagsLimit(t *testing.T) {
@@ -32,7 +33,7 @@ func Test_mStore_setMaxTagsLimit(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 
 	assert.NotZero(t, mStore.getMaxTagsLimit())
-	mStoreInterface.setMaxTagsLimit(1000)
+	mStoreInterface.SetMaxTagsLimit(1000)
 	assert.Equal(t, uint32(1000), mStore.getMaxTagsLimit())
 }
 
@@ -44,12 +45,12 @@ func Test_mStore_write_getOrCreateTStore_error(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().getTStore(gomock.Any()).Return(nil, false).AnyTimes()
-	mockTagIdx.EXPECT().getOrCreateTStore(gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
-	mockTagIdx.EXPECT().tagsUsed().Return(10).AnyTimes()
+	mockTagIdx.EXPECT().GetTStore(gomock.Any()).Return(nil, false).AnyTimes()
+	mockTagIdx.EXPECT().GetOrCreateTStore(gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
+	mockTagIdx.EXPECT().TagsUsed().Return(10).AnyTimes()
 
 	mStore.mutable = mockTagIdx
-	assert.NotNil(t, mStore.write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
+	assert.NotNil(t, mStore.Write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
 }
 
 func Test_mStore_isFull(t *testing.T) {
@@ -59,11 +60,11 @@ func Test_mStore_isFull(t *testing.T) {
 	mStoreInterface := newMetricStore(100)
 	mStore := mStoreInterface.(*metricStore)
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().tagsUsed().Return(10000000).AnyTimes()
+	mockTagIdx.EXPECT().TagsUsed().Return(10000000).AnyTimes()
 
 	mStore.mutable = mockTagIdx
 	assert.Equal(t, series.ErrTooManyTags,
-		mStoreInterface.write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
+		mStoreInterface.Write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
 }
 
 func Test_mStore_write_ok(t *testing.T) {
@@ -74,69 +75,63 @@ func Test_mStore_write_ok(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 
 	mockTStore := NewMocktStoreINTF(ctrl)
-	mockTStore.EXPECT().write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockTStore.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().tagsUsed().Return(1).AnyTimes()
-	mockTagIdx.EXPECT().updateTime(gomock.Any()).Return().AnyTimes()
-	mockTagIdx.EXPECT().getTStore(gomock.Any()).Return(nil, false).AnyTimes()
-	mockTagIdx.EXPECT().getOrCreateTStore(gomock.Any()).Return(mockTStore, nil).AnyTimes()
+	mockTagIdx.EXPECT().TagsUsed().Return(1).AnyTimes()
+	mockTagIdx.EXPECT().UpdateIndexTimeRange(gomock.Any()).Return().AnyTimes()
+	mockTagIdx.EXPECT().GetTStore(gomock.Any()).Return(nil, false).AnyTimes()
+	mockTagIdx.EXPECT().GetOrCreateTStore(gomock.Any()).Return(mockTStore, nil).AnyTimes()
 
 	mStore.mutable = mockTagIdx
-	assert.Nil(t, mStoreInterface.write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
+	assert.Nil(t, mStoreInterface.Write(&pb.Metric{Name: "metric", Tags: map[string]string{"type": "test"}}, writeContext{}))
 }
 
 func Test_mStore_resetVersion(t *testing.T) {
 	mStoreInterface := newMetricStore(100)
-	mStore := mStoreInterface.(*metricStore)
 
-	assert.Nil(t, mStore.immutable)
-	assert.NotNil(t, mStoreInterface.resetVersion())
-
-	tagIdx := mStore.mutable.(*tagIndex)
-	tagIdx.version -= 3600 * 1000
-	mStore.mutable = tagIdx
-	assert.Nil(t, mStoreInterface.resetVersion())
-	assert.NotNil(t, mStore.immutable)
+	assert.Nil(t, mStoreInterface.ResetVersion())
+	assert.NotNil(t, mStoreInterface.ResetVersion())
+	assert.NotNil(t, mStoreInterface.ResetVersion())
 }
 
 func Test_mStore_evict(t *testing.T) {
 	mStoreInterface := newMetricStore(100)
 	mStore := mStoreInterface.(*metricStore)
 	// evict on empty
-	mStore.evict()
-	assert.True(t, mStore.isEmpty())
+	mStore.Evict()
+	assert.True(t, mStore.IsEmpty())
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	// mock tStores
 	mockTStore1 := NewMocktStoreINTF(ctrl)
-	mockTStore1.EXPECT().isNoData().Return(true).AnyTimes()
-	mockTStore1.EXPECT().isExpired().Return(false).AnyTimes()
+	mockTStore1.EXPECT().IsNoData().Return(true).AnyTimes()
+	mockTStore1.EXPECT().IsExpired().Return(false).AnyTimes()
 	mockTStore2 := NewMocktStoreINTF(ctrl)
-	mockTStore2.EXPECT().isNoData().Return(false).AnyTimes()
-	mockTStore2.EXPECT().isExpired().Return(false).AnyTimes()
+	mockTStore2.EXPECT().IsNoData().Return(false).AnyTimes()
+	mockTStore2.EXPECT().IsExpired().Return(false).AnyTimes()
 	mockTStore3 := NewMocktStoreINTF(ctrl)
-	mockTStore3.EXPECT().isNoData().Return(true).AnyTimes()
-	mockTStore3.EXPECT().isExpired().Return(true).AnyTimes()
+	mockTStore3.EXPECT().IsNoData().Return(true).AnyTimes()
+	mockTStore3.EXPECT().IsExpired().Return(true).AnyTimes()
 	mockTStore4 := NewMocktStoreINTF(ctrl)
-	mockTStore4.EXPECT().isNoData().Return(true).AnyTimes()
-	mockTStore4.EXPECT().isExpired().Return(true).AnyTimes()
+	mockTStore4.EXPECT().IsNoData().Return(true).AnyTimes()
+	mockTStore4.EXPECT().IsExpired().Return(true).AnyTimes()
 	// mock tagIndex
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().allTStores().Return(map[uint32]tStoreINTF{
+	mockTagIdx.EXPECT().AllTStores().Return(map[uint32]tStoreINTF{
 		11: mockTStore1,
 		22: mockTStore2,
 		33: mockTStore3,
 		44: mockTStore3,
 	})
-	mockTagIdx.EXPECT().getTStoreBySeriesID(uint32(33)).Return(mockTStore3, true).AnyTimes()
-	mockTagIdx.EXPECT().getTStoreBySeriesID(uint32(44)).Return(nil, false).AnyTimes()
-	mockTagIdx.EXPECT().removeTStores(uint32(33)).Return().AnyTimes()
+	mockTagIdx.EXPECT().GetTStoreBySeriesID(uint32(33)).Return(mockTStore3, true).AnyTimes()
+	mockTagIdx.EXPECT().GetTStoreBySeriesID(uint32(44)).Return(nil, false).AnyTimes()
+	mockTagIdx.EXPECT().RemoveTStores(uint32(33)).Return().AnyTimes()
 
 	mStore.mutable = mockTagIdx
-	mStoreInterface.evict()
+	mStoreInterface.Evict()
 }
 
 func Test_mStore_flushMetricsTo_error(t *testing.T) {
@@ -148,10 +143,22 @@ func Test_mStore_flushMetricsTo_error(t *testing.T) {
 
 	// mock tagIndex
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().flushMetricTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
-	mStore.immutable = []tagIndexINTF{mockTagIdx}
+	mockTagIdx.EXPECT().FlushMetricTo(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
+	mStore.mutable = mockTagIdx
+	assert.NotNil(t, mStoreInterface.FlushMetricsTo(nil, flushContext{}))
+}
 
-	assert.NotNil(t, mStoreInterface.flushMetricsTo(nil, flushContext{}))
+func Test_mStore_flushMetricsTo_withImmutable(t *testing.T) {
+	mStoreInterface := newMetricStore(100)
+	mStore := mStoreInterface.(*metricStore)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// mock tagIndex
+	mStore.mutable = newTagIndex()
+	_ = mStore.ResetVersion()
+	assert.Nil(t, mStoreInterface.FlushMetricsTo(nil, flushContext{}))
 }
 
 func Test_mStore_flushMetricsTo_OK(t *testing.T) {
@@ -163,17 +170,18 @@ func Test_mStore_flushMetricsTo_OK(t *testing.T) {
 
 	// mock tagIndex
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	mockTagIdx.EXPECT().flushMetricTo(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	mStore.immutable = []tagIndexINTF{mockTagIdx}
+	mockTagIdx.EXPECT().Version().Return(series.Version(1)).AnyTimes()
+	mockTagIdx.EXPECT().FlushMetricTo(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mStore.mutable = mockTagIdx
 
+	assert.Nil(t, mStore.atomicGetImmutable())
 	// mock flush field meta
 	mockTF := tblstore.NewMockMetricsDataFlusher(ctrl)
 	mockTF.EXPECT().FlushFieldMeta(gomock.Any(), gomock.Any()).AnyTimes()
-	mStore.fieldsMetas = append(mStore.fieldsMetas, fieldMeta{}, fieldMeta{})
+	mStore.fieldsMetas.Store(&fieldsMetas{fieldMeta{}, fieldMeta{}})
 
-	assert.Nil(t, mStoreInterface.flushMetricsTo(mockTF, flushContext{}))
-	assert.Nil(t, mStore.immutable)
+	assert.Nil(t, mStoreInterface.FlushMetricsTo(mockTF, flushContext{}))
+	assert.Nil(t, mStore.atomicGetImmutable())
 }
 
 func Test_mStore_findSeriesIDsByExpr_getSeriesIDsForTag(t *testing.T) {
@@ -184,31 +192,31 @@ func Test_mStore_findSeriesIDsByExpr_getSeriesIDsForTag(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTagIdx := NewMocktagIndexINTF(ctrl)
-	count := int64(0)
-	mockTagIdx.EXPECT().getVersion().DoAndReturn(func() int64 {
+	count := int64(1)
+	mockTagIdx.EXPECT().Version().DoAndReturn(func() series.Version {
 		count++
-		return count
+		return series.Version(count)
 	}).AnyTimes()
 
-	// mock findSeriesIDsByExpr
-	returnNotNil := mockTagIdx.EXPECT().findSeriesIDsByExpr(gomock.Any()).Return(roaring.New()).Times(2)
-	returnNil := mockTagIdx.EXPECT().findSeriesIDsByExpr(gomock.Any()).Return(nil).Times(2)
+	// mock FindSeriesIDsByExpr
+	returnNotNil := mockTagIdx.EXPECT().FindSeriesIDsByExpr(gomock.Any()).Return(roaring.New()).Times(2)
+	returnNil := mockTagIdx.EXPECT().FindSeriesIDsByExpr(gomock.Any()).Return(nil).Times(2)
 	gomock.InOrder(returnNotNil, returnNil)
 	// build mStore
-	mStore.immutable = []tagIndexINTF{mockTagIdx}
+	mStore.immutable.Store(mockTagIdx)
 	mStore.mutable = mockTagIdx
 	// result assert
-	set, err := mStoreInterface.findSeriesIDsByExpr(nil)
+	set, err := mStoreInterface.FindSeriesIDsByExpr(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, set)
-	_, err2 := mStoreInterface.findSeriesIDsByExpr(nil)
+	_, err2 := mStoreInterface.FindSeriesIDsByExpr(nil)
 	assert.Nil(t, err2)
-	// mock getSeriesIDsForTag
-	returnNotNil2 := mockTagIdx.EXPECT().getSeriesIDsForTag(gomock.Any()).Return(roaring.New()).Times(2)
-	returnNil2 := mockTagIdx.EXPECT().getSeriesIDsForTag(gomock.Any()).Return(nil).Times(2)
+	// mock GetSeriesIDsForTag
+	returnNotNil2 := mockTagIdx.EXPECT().GetSeriesIDsForTag(gomock.Any()).Return(roaring.New()).Times(2)
+	returnNil2 := mockTagIdx.EXPECT().GetSeriesIDsForTag(gomock.Any()).Return(nil).Times(2)
 	gomock.InOrder(returnNotNil2, returnNil2)
-	_, _ = mStoreInterface.getSeriesIDsForTag("")
-	_, _ = mStoreInterface.getSeriesIDsForTag("")
+	_, _ = mStoreInterface.GetSeriesIDsForTag("")
+	_, _ = mStoreInterface.GetSeriesIDsForTag("")
 }
 
 func Test_getFieldIDOrGenerate(t *testing.T) {
@@ -221,26 +229,28 @@ func Test_getFieldIDOrGenerate(t *testing.T) {
 	mockGen := diskdb.NewMockIDGenerator(ctrl)
 	// mock generate ok
 	mockGen.EXPECT().GenFieldID(uint32(100), "sum", field.SumField).Return(uint16(1), nil).AnyTimes()
-	fieldID, err := mStoreInterface.getFieldIDOrGenerate("sum", field.SumField, mockGen)
+	fieldID, err := mStoreInterface.GetFieldIDOrGenerate("sum", field.SumField, mockGen)
 	assert.Equal(t, uint16(1), fieldID)
 	assert.Nil(t, err)
 	// exist case
-	_, err = mStoreInterface.getFieldIDOrGenerate("sum", field.SumField, mockGen)
+	_, err = mStoreInterface.GetFieldIDOrGenerate("sum", field.SumField, mockGen)
 	// field not matches to the existed
 	assert.Nil(t, err)
-	_, err = mStoreInterface.getFieldIDOrGenerate("sum", field.MinField, mockGen)
+	_, err = mStoreInterface.GetFieldIDOrGenerate("sum", field.MinField, mockGen)
 	assert.NotNil(t, err)
 	// mock generate failure
 	mockGen.EXPECT().GenFieldID(uint32(100), "gen-error", field.SumField).
 		Return(uint16(1), series.ErrWrongFieldType)
-	_, err = mStoreInterface.getFieldIDOrGenerate("gen-error", field.SumField, mockGen)
+	_, err = mStoreInterface.GetFieldIDOrGenerate("gen-error", field.SumField, mockGen)
 	assert.NotNil(t, err)
 
 	// mock too many fields
+	var fieldsMetasList fieldsMetas
 	for range [3000]struct{}{} {
-		mStore.fieldsMetas = append(mStore.fieldsMetas, fieldMeta{})
+		fieldsMetasList = append(fieldsMetasList, fieldMeta{})
 	}
-	_, err = mStoreInterface.getFieldIDOrGenerate("sum", field.SumField, mockGen)
+	mStore.fieldsMetas.Store(&fieldsMetasList)
+	_, err = mStoreInterface.GetFieldIDOrGenerate("sum", field.SumField, mockGen)
 	assert.NotNil(t, err)
 }
 
@@ -254,9 +264,9 @@ func Test_getFieldIDOrGenerate_special_case(t *testing.T) {
 	mockGen.EXPECT().GenFieldID(uint32(100), "1", field.SumField).Return(uint16(1), nil).AnyTimes()
 	mockGen.EXPECT().GenFieldID(uint32(100), "2", field.SumField).Return(uint16(2), nil).AnyTimes()
 	mockGen.EXPECT().GenFieldID(uint32(100), "3", field.SumField).Return(uint16(3), nil).AnyTimes()
-	_, _ = mStoreInterface.getFieldIDOrGenerate("3", field.SumField, mockGen)
-	_, _ = mStoreInterface.getFieldIDOrGenerate("1", field.SumField, mockGen)
-	_, _ = mStoreInterface.getFieldIDOrGenerate("2", field.SumField, mockGen)
+	_, _ = mStoreInterface.GetFieldIDOrGenerate("3", field.SumField, mockGen)
+	_, _ = mStoreInterface.GetFieldIDOrGenerate("1", field.SumField, mockGen)
+	_, _ = mStoreInterface.GetFieldIDOrGenerate("2", field.SumField, mockGen)
 }
 
 func prepareMockTagIndexes(ctrl *gomock.Controller) (*MocktagIndexINTF, *MocktagIndexINTF, *MocktagIndexINTF) {
@@ -284,31 +294,31 @@ func prepareMockTagIndexes(ctrl *gomock.Controller) (*MocktagIndexINTF, *Mocktag
 			"nt": roaring.BitmapOf(6, 7, 8, 9, 10)}}}
 	// mock tag index interface
 	mockTagIdx1 := NewMocktagIndexINTF(ctrl)
-	mockTagIdx1.EXPECT().getTagKVEntrySets().Return(fakeKVEntrySet1).AnyTimes()
-	mockTagIdx1.EXPECT().getTimeRange().Return(uint32(1), uint32(2)).AnyTimes()
-	mockTagIdx1.EXPECT().getVersion().Return(series.Version(1)).AnyTimes()
-	mockTagIdx1.EXPECT().getTagKVEntrySet("host").Return(&fakeKVEntrySet1[0], true).AnyTimes()
-	mockTagIdx1.EXPECT().getTagKVEntrySet("zone").Return(&fakeKVEntrySet1[1], true).AnyTimes()
-	mockTagIdx1.EXPECT().getTagKVEntrySet("ip").Return(nil, false).AnyTimes()
-	mockTagIdx1.EXPECT().getTagKVEntrySet("usage").Return(nil, false).AnyTimes()
+	mockTagIdx1.EXPECT().GetTagKVEntrySets().Return(fakeKVEntrySet1).AnyTimes()
+	mockTagIdx1.EXPECT().IndexTimeRange().Return(timeutil.TimeRange{Start: 1, End: 2}).AnyTimes()
+	mockTagIdx1.EXPECT().Version().Return(series.Version(1)).AnyTimes()
+	mockTagIdx1.EXPECT().GetTagKVEntrySet("host").Return(&fakeKVEntrySet1[0], true).AnyTimes()
+	mockTagIdx1.EXPECT().GetTagKVEntrySet("zone").Return(&fakeKVEntrySet1[1], true).AnyTimes()
+	mockTagIdx1.EXPECT().GetTagKVEntrySet("ip").Return(nil, false).AnyTimes()
+	mockTagIdx1.EXPECT().GetTagKVEntrySet("usage").Return(nil, false).AnyTimes()
 
 	mockTagIdx2 := NewMocktagIndexINTF(ctrl)
-	mockTagIdx2.EXPECT().getTagKVEntrySets().Return(fakeKVEntrySet2).AnyTimes()
-	mockTagIdx2.EXPECT().getTimeRange().Return(uint32(1), uint32(2)).AnyTimes()
-	mockTagIdx2.EXPECT().getVersion().Return(series.Version(2)).AnyTimes()
-	mockTagIdx2.EXPECT().getTagKVEntrySet("ip").Return(&fakeKVEntrySet2[0], true).AnyTimes()
-	mockTagIdx2.EXPECT().getTagKVEntrySet("host").Return(nil, false).AnyTimes()
-	mockTagIdx2.EXPECT().getTagKVEntrySet("usage").Return(nil, false).AnyTimes()
-	mockTagIdx2.EXPECT().getTagKVEntrySet("zone").Return(&fakeKVEntrySet2[1], true).AnyTimes()
+	mockTagIdx2.EXPECT().GetTagKVEntrySets().Return(fakeKVEntrySet2).AnyTimes()
+	mockTagIdx2.EXPECT().IndexTimeRange().Return(timeutil.TimeRange{Start: 1, End: 2}).AnyTimes()
+	mockTagIdx2.EXPECT().Version().Return(series.Version(2)).AnyTimes()
+	mockTagIdx2.EXPECT().GetTagKVEntrySet("ip").Return(&fakeKVEntrySet2[0], true).AnyTimes()
+	mockTagIdx2.EXPECT().GetTagKVEntrySet("host").Return(nil, false).AnyTimes()
+	mockTagIdx2.EXPECT().GetTagKVEntrySet("usage").Return(nil, false).AnyTimes()
+	mockTagIdx2.EXPECT().GetTagKVEntrySet("zone").Return(&fakeKVEntrySet2[1], true).AnyTimes()
 
 	mockTagIdx3 := NewMocktagIndexINTF(ctrl)
-	mockTagIdx3.EXPECT().getTagKVEntrySets().Return(fakeKVEntrySet3).AnyTimes()
-	mockTagIdx3.EXPECT().getTimeRange().Return(uint32(1), uint32(2)).AnyTimes()
-	mockTagIdx3.EXPECT().getVersion().Return(series.Version(3)).AnyTimes()
-	mockTagIdx3.EXPECT().getTagKVEntrySet("usage").Return(&fakeKVEntrySet3[0], true).AnyTimes()
-	mockTagIdx3.EXPECT().getTagKVEntrySet("host").Return(nil, false).AnyTimes()
-	mockTagIdx3.EXPECT().getTagKVEntrySet("ip").Return(nil, false).AnyTimes()
-	mockTagIdx3.EXPECT().getTagKVEntrySet("zone").Return(&fakeKVEntrySet3[1], true).AnyTimes()
+	mockTagIdx3.EXPECT().GetTagKVEntrySets().Return(fakeKVEntrySet3).AnyTimes()
+	mockTagIdx3.EXPECT().IndexTimeRange().Return(timeutil.TimeRange{Start: 1, End: 2}).AnyTimes()
+	mockTagIdx3.EXPECT().Version().Return(series.Version(3)).AnyTimes()
+	mockTagIdx3.EXPECT().GetTagKVEntrySet("usage").Return(&fakeKVEntrySet3[0], true).AnyTimes()
+	mockTagIdx3.EXPECT().GetTagKVEntrySet("host").Return(nil, false).AnyTimes()
+	mockTagIdx3.EXPECT().GetTagKVEntrySet("ip").Return(nil, false).AnyTimes()
+	mockTagIdx3.EXPECT().GetTagKVEntrySet("zone").Return(&fakeKVEntrySet3[1], true).AnyTimes()
 
 	return mockTagIdx1, mockTagIdx2, mockTagIdx3
 }
@@ -318,11 +328,11 @@ func Test_mStore_flushInvertedIndexTo(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mockTagIdx1, mockTagIdx2, mockTagIdx3 := prepareMockTagIndexes(ctrl)
+	mockTagIdx1, _, mockTagIdx3 := prepareMockTagIndexes(ctrl)
 
 	// mock index-table series flusher
 	mockTableFlusher := tblstore.NewMockInvertedIndexFlusher(ctrl)
-	mockTableFlusher.EXPECT().FlushVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+	mockTableFlusher.EXPECT().FlushVersion(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return().AnyTimes()
 	mockTableFlusher.EXPECT().FlushTagValue(gomock.Any()).Return().AnyTimes()
 
@@ -332,22 +342,22 @@ func Test_mStore_flushInvertedIndexTo(t *testing.T) {
 	mStore.mutable = mockTagIdx1
 	// flush ok
 	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(nil).Times(2)
-	assert.Nil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
+	assert.Nil(t, mStore.FlushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 	// flush error
 	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
-	assert.NotNil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
+	assert.NotNil(t, mStore.FlushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 
 	//////////////////////////////////////////////
 	// neither mutable nor immutable part is empty
 	//////////////////////////////////////////////
-	mStore.immutable = []tagIndexINTF{mockTagIdx1, mockTagIdx2}
+	mStore.immutable.Store(mockTagIdx1)
 	mStore.mutable = mockTagIdx3
 	// flush error
 	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(fmt.Errorf("error")).Times(1)
-	assert.NotNil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
+	assert.NotNil(t, mStore.FlushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 	// flush ok
-	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(nil).Times(4)
-	assert.Nil(t, mStore.flushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
+	mockTableFlusher.EXPECT().FlushTagKeyID(gomock.Any()).Return(nil).Times(3)
+	assert.Nil(t, mStore.FlushInvertedIndexTo(mockTableFlusher, makeMockIDGenerator(ctrl)))
 }
 
 func Test_mStore_flushForwardIndexTo(t *testing.T) {
@@ -361,20 +371,20 @@ func Test_mStore_flushForwardIndexTo(t *testing.T) {
 	mockTableFlusher := tblstore.NewMockForwardIndexFlusher(ctrl)
 	mockTableFlusher.EXPECT().FlushTagValue(gomock.Any(), gomock.Any()).Return().AnyTimes()
 	mockTableFlusher.EXPECT().FlushTagKey(gomock.Any()).Return().AnyTimes()
-	mockTableFlusher.EXPECT().FlushVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
+	mockTableFlusher.EXPECT().FlushVersion(gomock.Any(), gomock.Any()).Return().AnyTimes()
 	mockTableFlusher.EXPECT().FlushMetricID(gomock.Any()).Return(nil).AnyTimes()
 
 	//////////////////////////////////////////////
 	// immutable part empty
 	//////////////////////////////////////////////
 	mStore.mutable = mockTagIdx1
-	assert.Nil(t, mStoreInterface.flushForwardIndexTo(mockTableFlusher))
+	assert.Nil(t, mStoreInterface.FlushForwardIndexTo(mockTableFlusher))
 	//////////////////////////////////////////////
 	// neither mutable nor immutable part is empty
 	//////////////////////////////////////////////
-	mStore.immutable = []tagIndexINTF{mockTagIdx1, mockTagIdx2}
+	mStore.immutable.Store(mockTagIdx2)
 	mStore.mutable = mockTagIdx3
-	assert.Nil(t, mStoreInterface.flushForwardIndexTo(mockTableFlusher))
+	assert.Nil(t, mStoreInterface.FlushForwardIndexTo(mockTableFlusher))
 }
 
 func Test_mStore_getTagValues(t *testing.T) {
@@ -382,20 +392,20 @@ func Test_mStore_getTagValues(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mockTagIdx1, mockTagIdx2, mockTagIdx3 := prepareMockTagIndexes(ctrl)
+	_, mockTagIdx2, mockTagIdx3 := prepareMockTagIndexes(ctrl)
 
 	//////////////////////////////////////////////
 	// immutable part empty
 	//////////////////////////////////////////////
 	mStore.mutable = mockTagIdx3
 	// host not exist
-	mappings, err := mStoreInterface.getTagValues(
+	mappings, err := mStoreInterface.GetTagValues(
 		[]string{"host", "zone", "usage"}, 3, roaring.BitmapOf(3, 4, 5, 6, 11))
 	assert.NotNil(t, err)
 	assert.Nil(t, mappings)
 
 	// zone, usage exist
-	mappings, err = mStoreInterface.getTagValues(
+	mappings, err = mStoreInterface.GetTagValues(
 		[]string{"zone", "usage"}, 3, roaring.BitmapOf(3, 4, 5, 6, 11))
 	assert.Nil(t, err)
 	assert.Len(t, mappings, 5)
@@ -407,13 +417,13 @@ func Test_mStore_getTagValues(t *testing.T) {
 	//////////////////////////////////////////////
 	// immutable part not empty
 	//////////////////////////////////////////////
-	mStore.immutable = []tagIndexINTF{mockTagIdx1, mockTagIdx2}
+	mStore.immutable.Store(mockTagIdx2)
 	mStore.mutable = mockTagIdx3
 	// version not match
-	_, err = mStoreInterface.getTagValues([]string{"ip"}, 4, roaring.BitmapOf(1, 2, 3))
+	_, err = mStoreInterface.GetTagValues([]string{"ip"}, 4, roaring.BitmapOf(1, 2, 3))
 	assert.NotNil(t, err)
 	// version match, ip not exist
-	_, err = mStoreInterface.getTagValues([]string{"ip"}, 1, roaring.BitmapOf(1, 2, 3))
+	_, err = mStoreInterface.GetTagValues([]string{"ip"}, 1, roaring.BitmapOf(1, 2, 3))
 	assert.NotNil(t, err)
 }
 
@@ -422,17 +432,17 @@ func Test_mStore_suggest(t *testing.T) {
 	mStore := mStoreInterface.(*metricStore)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mockTagIdx1, mockTagIdx2, mockTagIdx3 := prepareMockTagIndexes(ctrl)
+	mockTagIdx1, _, mockTagIdx3 := prepareMockTagIndexes(ctrl)
 
 	// invalid limit
-	assert.Nil(t, mStoreInterface.suggestTagValues("", "", 0))
-	assert.Nil(t, mStoreInterface.suggestTagKeys("", 0))
+	assert.Nil(t, mStoreInterface.SuggestTagValues("", "", 0))
+	assert.Nil(t, mStoreInterface.SuggestTagKeys("", 0))
 
-	mStore.immutable = []tagIndexINTF{mockTagIdx1, mockTagIdx2}
+	mStore.immutable.Store(mockTagIdx1)
 	mStore.mutable = mockTagIdx3
 
-	assert.Len(t, mStoreInterface.suggestTagKeys("host", 1), 1)
-	assert.Len(t, mStoreInterface.suggestTagKeys("host", 3), 1)
-	assert.Len(t, mStoreInterface.suggestTagValues("host", "a", 1), 1)
-	assert.Len(t, mStoreInterface.suggestTagValues("host", "a", 100000), 1)
+	assert.Len(t, mStoreInterface.SuggestTagKeys("host", 1), 1)
+	assert.Len(t, mStoreInterface.SuggestTagKeys("host", 3), 1)
+	assert.Len(t, mStoreInterface.SuggestTagValues("host", "a", 1), 1)
+	assert.Len(t, mStoreInterface.SuggestTagValues("host", "a", 100000), 1)
 }

--- a/tsdb/memdb/segment_store.go
+++ b/tsdb/memdb/segment_store.go
@@ -13,11 +13,11 @@ import (
 // sStoreINTF represents segment-store,
 // which abstracts a store for storing field data based on family start time
 type sStoreINTF interface {
-	getFamilyTime() int64
-	slotRange() (startSlot, endSlot int, err error)
-	bytes(needSlotRange bool) (data []byte, startSlot, endSlot int, err error)
-	writeInt(value int64, writeCtx writeContext)
-	writeFloat(value float64, writeCtx writeContext)
+	GetFamilyTime() int64
+	SlotRange() (startSlot, endSlot int, err error)
+	Bytes(needSlotRange bool) (data []byte, startSlot, endSlot int, err error)
+	WriteInt(value int64, writeCtx writeContext)
+	WriteFloat(value float64, writeCtx writeContext)
 }
 
 // singleFieldStore stores single field
@@ -35,7 +35,7 @@ func newSimpleFieldStore(familyTime int64, aggFunc field.AggFunc) sStoreINTF {
 	}
 }
 
-func (fs *simpleFieldStore) getFamilyTime() int64 {
+func (fs *simpleFieldStore) GetFamilyTime() int64 {
 	return fs.familyTime
 }
 
@@ -44,7 +44,7 @@ func (fs *simpleFieldStore) AggFunc() field.AggFunc {
 	return fs.aggFunc
 }
 
-func (fs *simpleFieldStore) writeFloat(value float64, writeCtx writeContext) {
+func (fs *simpleFieldStore) WriteFloat(value float64, writeCtx writeContext) {
 	pos, hasValue := fs.calcTimeWindow(writeCtx.blockStore, writeCtx.slotIndex, field.Float)
 	currentBlock := fs.block
 	if hasValue {
@@ -55,7 +55,7 @@ func (fs *simpleFieldStore) writeFloat(value float64, writeCtx writeContext) {
 	}
 }
 
-func (fs *simpleFieldStore) writeInt(value int64, writeCtx writeContext) {
+func (fs *simpleFieldStore) WriteInt(value int64, writeCtx writeContext) {
 	pos, hasValue := fs.calcTimeWindow(writeCtx.blockStore, writeCtx.slotIndex, field.Integer)
 	currentBlock := fs.block
 	if hasValue {
@@ -107,7 +107,7 @@ func (fs *simpleFieldStore) calcTimeWindow(blockStore *blockStore, slotTime int,
 	return pos, needRollup
 }
 
-func (fs *simpleFieldStore) bytes(needSlotRange bool) (data []byte, startSlot, endSlot int, err error) {
+func (fs *simpleFieldStore) Bytes(needSlotRange bool) (data []byte, startSlot, endSlot int, err error) {
 	if fs.block == nil {
 		err = fmt.Errorf("block is empty")
 		return
@@ -120,7 +120,7 @@ func (fs *simpleFieldStore) bytes(needSlotRange bool) (data []byte, startSlot, e
 	return
 }
 
-func (fs *simpleFieldStore) slotRange() (startSlot, endSlot int, err error) {
+func (fs *simpleFieldStore) SlotRange() (startSlot, endSlot int, err error) {
 	if fs.block == nil {
 		err = fmt.Errorf("block is empty")
 		return

--- a/tsdb/memdb/segment_store_test.go
+++ b/tsdb/memdb/segment_store_test.go
@@ -14,16 +14,16 @@ import (
 func TestSimpleSegmentStore(t *testing.T) {
 	aggFunc := field.GetAggFunc(field.Sum)
 	store := newSimpleFieldStore(0, aggFunc)
-	assert.Equal(t, int64(0), store.getFamilyTime())
+	assert.Equal(t, int64(0), store.GetFamilyTime())
 	assert.NotNil(t, store)
 	ss, ok := store.(*simpleFieldStore)
 	assert.True(t, ok)
 	assert.Equal(t, aggFunc, ss.AggFunc())
 
-	_, _, err := ss.slotRange()
+	_, _, err := ss.SlotRange()
 	assert.NotNil(t, err)
 
-	compress, startSlot, endSlot, err := store.bytes(true)
+	compress, startSlot, endSlot, err := store.Bytes(true)
 	assert.Nil(t, compress)
 	assert.NotNil(t, err)
 	assert.Equal(t, 0, startSlot)
@@ -37,29 +37,29 @@ func TestSimpleSegmentStore(t *testing.T) {
 	}
 
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// memory auto rollup
 	writeCtx.slotIndex = 11
-	ss.writeInt(110, writeCtx)
+	ss.WriteInt(110, writeCtx)
 	// memory auto rollup
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// compact because slot out of current time window
 	writeCtx.slotIndex = 40
-	ss.writeInt(20, writeCtx)
+	ss.WriteInt(20, writeCtx)
 	// compact before time window
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// compact because slot out of current time window
 	writeCtx.slotIndex = 41
-	ss.writeInt(50, writeCtx)
+	ss.WriteInt(50, writeCtx)
 
-	compress, startSlot, endSlot, err = store.bytes(true)
+	compress, startSlot, endSlot, err = store.Bytes(true)
 	assert.Nil(t, err)
 	assert.Equal(t, 10, startSlot)
 	assert.Equal(t, 41, endSlot)
 
-	startSlot, endSlot, err = store.slotRange()
+	startSlot, endSlot, err = store.SlotRange()
 	assert.Nil(t, err)
 	assert.Equal(t, 10, startSlot)
 	assert.Equal(t, 41, endSlot)
@@ -82,7 +82,7 @@ func TestSimpleSegmentStore(t *testing.T) {
 
 	// write float test
 	writeCtx.slotIndex = 10
-	ss.writeFloat(10, writeCtx)
+	ss.WriteFloat(10, writeCtx)
 }
 
 func Test_sStore_error(t *testing.T) {
@@ -97,7 +97,7 @@ func Test_sStore_error(t *testing.T) {
 	mockBlock.EXPECT().getStartTime().Return(12).AnyTimes()
 	mockBlock.EXPECT().getEndTime().Return(40).AnyTimes()
 	ss.block = mockBlock
-	_, _, _, err := ss.bytes(false)
+	_, _, _, err := ss.Bytes(false)
 	assert.NotNil(t, err)
 
 	writeCtx := writeContext{
@@ -108,10 +108,10 @@ func Test_sStore_error(t *testing.T) {
 	}
 
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// memory auto rollup
 	writeCtx.slotIndex = 11
-	ss.writeInt(110, writeCtx)
+	ss.WriteInt(110, writeCtx)
 }
 
 func BenchmarkSimpleSegmentStore(b *testing.B) {
@@ -127,22 +127,22 @@ func BenchmarkSimpleSegmentStore(b *testing.B) {
 	}
 
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// memory auto rollup
 	writeCtx.slotIndex = 11
-	ss.writeInt(110, writeCtx)
+	ss.WriteInt(110, writeCtx)
 	// memory auto rollup
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// compact because slot out of current time window
 	writeCtx.slotIndex = 40
-	ss.writeInt(20, writeCtx)
+	ss.WriteInt(20, writeCtx)
 	// compact before time window
 	writeCtx.slotIndex = 10
-	ss.writeInt(100, writeCtx)
+	ss.WriteInt(100, writeCtx)
 	// compact because slot out of current time window
 	writeCtx.slotIndex = 41
-	ss.writeInt(50, writeCtx)
+	ss.WriteInt(50, writeCtx)
 
-	_, _, _, _ = store.bytes(true)
+	_, _, _, _ = store.Bytes(true)
 }

--- a/tsdb/memdb/timeseries_store.go
+++ b/tsdb/memdb/timeseries_store.go
@@ -2,6 +2,9 @@ package memdb
 
 import (
 	"sort"
+	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/lindb/lindb/pkg/lockers"
 	"github.com/lindb/lindb/pkg/timeutil"
@@ -15,20 +18,34 @@ import (
 
 // tStoreINTF abstracts a time-series store
 type tStoreINTF interface {
-	// getHash returns the FNV1a hash of the tags
-	getHash() uint64
-	// getFStore returns the fStore in this list from field-id.
-	getFStore(fieldID uint16) (fStoreINTF, bool)
-	// write writes the metric
-	write(metric *pb.Metric, writeCtx writeContext) error
-	// flushSeriesTo flushes the series data segment.
-	flushSeriesTo(flusher tblstore.MetricsDataFlusher, flushCtx flushContext, seriesID uint32) (flushed bool)
-	// isExpired detects if this tStore has not been used for a TTL
-	isExpired() bool
-	// isNoData symbols if all data of this tStore has been flushed
-	isNoData() bool
-	// scan scans time series store, then finds data by field id and time range
-	scan(sCtx *series.ScanContext, version series.Version, seriesID uint32, fieldMetas map[uint16]*fieldMeta)
+	// GetHash returns the FNV1a hash of the tags
+	GetHash() uint64
+
+	// GetFStore returns the fStore in this list from field-id.
+	GetFStore(fieldID uint16) (fStoreINTF, bool)
+
+	// Write writes the metric
+	Write(metric *pb.Metric, writeCtx writeContext) error
+
+	// FlushSeriesTo flushes the series data segment.
+	FlushSeriesTo(
+		flusher tblstore.MetricsDataFlusher,
+		flushCtx flushContext,
+		seriesID uint32,
+	) (flushed bool)
+
+	// IsExpired detects if this tStore has not been used for a TTL
+	IsExpired() bool
+
+	// IsNoData symbols if all data of this tStore has been flushed
+	IsNoData() bool
+
+	// Scan scans time series store, then finds data by field id and time range
+	Scan(
+		sCtx *series.ScanContext,
+		version series.Version,
+		seriesID uint32,
+		fieldMetas map[uint16]*fieldMeta)
 }
 
 // fStoreNodes implements sort.Interface
@@ -42,8 +59,7 @@ func (f fStoreNodes) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
 type timeSeriesStore struct {
 	sl            lockers.SpinLock // spin-lock
 	hash          uint64           // hash of tags
-	lastWroteTime uint32           // last write-time in seconds
-	hasData       bool             // noData flags symbols if all data has been flushed
+	lastWroteTime atomic.Uint32    // last Write-time in seconds
 	fStoreNodes   fStoreNodes      // key: sorted fStore list by field-name, insert-only
 }
 
@@ -51,16 +67,16 @@ type timeSeriesStore struct {
 func newTimeSeriesStore(tagsHash uint64) tStoreINTF {
 	return &timeSeriesStore{
 		hash:          tagsHash,
-		lastWroteTime: uint32(timeutil.Now() / 1000)}
+		lastWroteTime: *atomic.NewUint32(uint32(timeutil.Now() / 1000))}
 }
 
-// getHash returns the FNV1a hash of the tags
-func (ts *timeSeriesStore) getHash() uint64 {
+// GetHash returns the FNV1a hash of the tags
+func (ts *timeSeriesStore) GetHash() uint64 {
 	return ts.hash
 }
 
-// getFStore returns the fStore in this list from field-id.
-func (ts *timeSeriesStore) getFStore(fieldID uint16) (fStoreINTF, bool) {
+// GetFStore returns the fStore in this list from field-id.
+func (ts *timeSeriesStore) GetFStore(fieldID uint16) (fStoreINTF, bool) {
 	idx := sort.Search(len(ts.fStoreNodes), func(i int) bool {
 		return ts.fStoreNodes[i].GetFieldID() >= fieldID
 	})
@@ -76,30 +92,28 @@ func (ts *timeSeriesStore) insertFStore(fStore fStoreINTF) {
 	sort.Sort(ts.fStoreNodes)
 }
 
-// isNoData symbols if all data of this tStore has been flushed
-func (ts *timeSeriesStore) isNoData() bool {
-	return !ts.hasData
-}
+// IsNoData symbols if all data of this tStore has been flushed
+func (ts *timeSeriesStore) IsNoData() bool {
+	ts.sl.Lock()
+	defer ts.sl.Unlock()
 
-// afterWrite set hasData to true and updates the lastWroteTime
-func (ts *timeSeriesStore) afterWrite() {
-	// hasData is true now
-	ts.hasData = true
-	// update lastWroteTime
-	ts.lastWroteTime = uint32(timeutil.Now() / 1000)
+	for _, fStore := range ts.fStoreNodes {
+		if fStore.SegmentsCount() != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // afterFlush checks if the tStore contains any data after flushing
 func (ts *timeSeriesStore) afterFlush(flushCtx flushContext) {
 	// update hasData flag
 	var startTime, endTime int64
-	ts.hasData = false
 	for _, fStore := range ts.fStoreNodes {
 		timeRange, ok := fStore.TimeRange(flushCtx.timeInterval)
 		if !ok {
 			continue
 		}
-		ts.hasData = true
 		if startTime == 0 || timeRange.Start < startTime {
 			startTime = timeRange.Start
 		}
@@ -109,13 +123,16 @@ func (ts *timeSeriesStore) afterFlush(flushCtx flushContext) {
 	}
 }
 
-// isExpired detects if this tStore has not been used for a TTL
-func (ts *timeSeriesStore) isExpired() bool {
-	return int64(ts.lastWroteTime)*1000+getTagsIDTTL() < timeutil.Now()
+// IsExpired detects if this tStore has not been used for a TTL
+func (ts *timeSeriesStore) IsExpired() bool {
+	return time.Unix(int64(ts.lastWroteTime.Load()), 0).Add(seriesTTL.Load()).Before(time.Now())
 }
 
-// write write the data of metric to the fStore.
-func (ts *timeSeriesStore) write(metric *pb.Metric, writeCtx writeContext) error {
+// Write Write the data of metric to the fStore.
+func (ts *timeSeriesStore) Write(
+	metric *pb.Metric,
+	writeCtx writeContext,
+) error {
 	ts.sl.Lock()
 	defer ts.sl.Unlock()
 
@@ -128,7 +145,7 @@ func (ts *timeSeriesStore) write(metric *pb.Metric, writeCtx writeContext) error
 		}
 		if fStore, err := ts.getOrCreateFStore(f.Name, fieldType, writeCtx); err == nil {
 			fStore.Write(f, writeCtx)
-			ts.afterWrite()
+			ts.lastWroteTime.Store(uint32(timeutil.Now() / 1000))
 		} else {
 			return err // field type do not match before, too many fields
 		}
@@ -137,14 +154,20 @@ func (ts *timeSeriesStore) write(metric *pb.Metric, writeCtx writeContext) error
 }
 
 // getOrCreateFStore get a fieldStore by fieldName and fieldType
-func (ts *timeSeriesStore) getOrCreateFStore(fieldName string, fieldType field.Type,
-	writeCtx writeContext) (fStoreINTF, error) {
-	fieldID, err := writeCtx.getFieldIDOrGenerate(fieldName, fieldType, writeCtx.generator)
+func (ts *timeSeriesStore) getOrCreateFStore(
+	fieldName string,
+	fieldType field.Type,
+	writeCtx writeContext,
+) (
+	fStoreINTF,
+	error,
+) {
+	fieldID, err := writeCtx.GetFieldIDOrGenerate(fieldName, fieldType, writeCtx.generator)
 	if err != nil {
 		return nil, err
 	}
 
-	fStore, ok := ts.getFStore(fieldID)
+	fStore, ok := ts.GetFStore(fieldID)
 	if !ok {
 		fStore = newFieldStore(fieldID)
 		ts.insertFStore(fStore)
@@ -152,9 +175,12 @@ func (ts *timeSeriesStore) getOrCreateFStore(fieldName string, fieldType field.T
 	return fStore, nil
 }
 
-// flushSeriesTo flushes the series data segment.
-func (ts *timeSeriesStore) flushSeriesTo(flusher tblstore.MetricsDataFlusher,
-	flushCtx flushContext, seriesID uint32) (flushed bool) {
+// FlushSeriesTo flushes the series data segment.
+func (ts *timeSeriesStore) FlushSeriesTo(
+	flusher tblstore.MetricsDataFlusher,
+	flushCtx flushContext,
+	seriesID uint32,
+) (flushed bool) {
 	ts.sl.Lock()
 	for _, fStore := range ts.fStoreNodes {
 		fieldDataFlushed := fStore.FlushFieldTo(flusher, flushCtx.familyTime)

--- a/tsdb/memdb/timeseries_store_scan.go
+++ b/tsdb/memdb/timeseries_store_scan.go
@@ -4,18 +4,23 @@ import (
 	"github.com/lindb/lindb/series"
 )
 
-// scan scans time series data, then finds field store by field id
-func (ts *timeSeriesStore) scan(sCtx *series.ScanContext, version series.Version, seriesID uint32, fieldMetas map[uint16]*fieldMeta) {
+// Scan scans time series data, then finds field store by field id
+func (ts *timeSeriesStore) Scan(
+	sCtx *series.ScanContext,
+	version series.Version,
+	seriesID uint32,
+	fieldMetas map[uint16]*fieldMeta,
+) {
 	worker := sCtx.Worker
 	for _, fieldID := range sCtx.FieldIDs {
 		ts.sl.Lock()
-		fStore, ok := ts.getFStore(fieldID)
+		fStore, ok := ts.GetFStore(fieldID)
 		ts.sl.Unlock()
 		if !ok {
 			continue
 		}
 		fieldMeta := fieldMetas[fieldID]
-		fStore.scan(sCtx, version, seriesID, fieldMeta, ts)
+		fStore.Scan(sCtx, version, seriesID, fieldMeta, ts)
 	}
 
 	// send msg to notify current series scan completed

--- a/tsdb/tblstore/forward_index_flusher_test.go
+++ b/tsdb/tblstore/forward_index_flusher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/pkg/timeutil"
 	"github.com/lindb/lindb/series"
 
 	"github.com/RoaringBitmap/roaring"
@@ -39,7 +40,7 @@ func Test_ForwardIndexFlush(t *testing.T) {
 			}
 			mockFlusher.FlushTagKey(string(x))
 		}
-		mockFlusher.FlushVersion(series.Version(v), 0, 10)
+		mockFlusher.FlushVersion(series.Version(v), timeutil.TimeRange{Start: 0, End: 10})
 	}
 	assert.Nil(t, mockFlusher.FlushMetricID(1))
 

--- a/tsdb/tblstore/forward_index_merger_test.go
+++ b/tsdb/tblstore/forward_index_merger_test.go
@@ -26,16 +26,16 @@ func buildForwardIndexBlockToCompact() (data [][]byte) {
 		flusher.FlushTagKey("ip")
 	}
 	flushVersion(10)
-	flusher.FlushVersion(series.Version(now-3600*1000*24*60), 1, 2)
+	flusher.FlushVersion(series.Version(now-3600*1000*24*60), timeutil.TimeRange{Start: 1, End: 2})
 	flushVersion(10)
-	flusher.FlushVersion(series.Version(now-3600*1000*24*20), 1, 2)
+	flusher.FlushVersion(series.Version(now-3600*1000*24*20), timeutil.TimeRange{Start: 1, End: 2})
 	_ = flusher.FlushMetricID(1)
 	data = append(data, append([]byte{}, nopKVFlusher.Bytes()...))
 
 	flushVersion(12)
-	flusher.FlushVersion(series.Version(now-3600*1000*24*35), 1, 2)
+	flusher.FlushVersion(series.Version(now-3600*1000*24*35), timeutil.TimeRange{Start: 1, End: 2})
 	flushVersion(12)
-	flusher.FlushVersion(series.Version(now-3600*1000*24*20), 1, 2)
+	flusher.FlushVersion(series.Version(now-3600*1000*24*20), timeutil.TimeRange{Start: 1, End: 2})
 	_ = flusher.FlushMetricID(1)
 	data = append(data, append([]byte{}, nopKVFlusher.Bytes()...))
 

--- a/tsdb/tblstore/forward_index_reader.go
+++ b/tsdb/tblstore/forward_index_reader.go
@@ -41,8 +41,8 @@ type forwardIndexReader struct {
 }
 
 type forwardIndexVersionEntry struct {
-	startTime           uint32
-	endTime             uint32
+	startTimeDelta      int32
+	endTimeDelta        int32
 	tagKeys             []string // tagKeySeq -> tagKey
 	tagKeysBitArraySize int
 	offsets             []int32
@@ -79,8 +79,8 @@ func newForwardIndexVersionEntry(
 	}
 	// Read TimeRange Block
 	entry.sr.SeekStart()
-	entry.startTime = entry.sr.ReadUint32()
-	entry.endTime = entry.sr.ReadUint32()
+	entry.startTimeDelta = entry.sr.ReadInt32()
+	entry.endTimeDelta = entry.sr.ReadInt32()
 	// Read TagKeys Block
 	if err := entry.readTagKeys(); err != nil {
 		return nil, err

--- a/tsdb/tblstore/forward_index_reader_test.go
+++ b/tsdb/tblstore/forward_index_reader_test.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"testing"
 
+	"github.com/lindb/lindb/pkg/timeutil"
+
 	"github.com/lindb/lindb/kv"
 	"github.com/lindb/lindb/kv/table"
 	"github.com/lindb/lindb/series"
@@ -76,7 +78,7 @@ func buildForwardIndexBlock() []byte {
 		}
 		flusher.FlushTagKey("host")
 		// flush version
-		flusher.FlushVersion(series.Version(v), uint32(v*100), uint32(v+1)*100)
+		flusher.FlushVersion(series.Version(v), timeutil.TimeRange{Start: int64(v) * 100, End: (int64(v) + 1) * 100})
 	}
 
 	_ = flusher.FlushMetricID(1)

--- a/tsdb/tblstore/inverted_index_flusher_test.go
+++ b/tsdb/tblstore/inverted_index_flusher_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lindb/lindb/pkg/timeutil"
+
 	"github.com/lindb/lindb/kv"
 
 	"github.com/RoaringBitmap/roaring"
@@ -70,15 +72,15 @@ func Test_SeriesIndexFlusher_OK(t *testing.T) {
 	indexFlusher := NewInvertedIndexFlusher(mockFlusher)
 
 	// flush versions of tagValue1
-	indexFlusher.FlushVersion(1, 3, 5, roaring.New())
-	indexFlusher.FlushVersion(2, 4, 6, roaring.New())
-	indexFlusher.FlushVersion(3, 1, 2, roaring.New())
+	indexFlusher.FlushVersion(1, timeutil.TimeRange{Start: 3, End: 5}, roaring.New())
+	indexFlusher.FlushVersion(2, timeutil.TimeRange{Start: 4, End: 6}, roaring.New())
+	indexFlusher.FlushVersion(3, timeutil.TimeRange{Start: 1, End: 2}, roaring.New())
 	// flush tagValue1
 	indexFlusher.FlushTagValue("1")
 	// flush versions of tagValue2
-	indexFlusher.FlushVersion(1, 12, 15, roaring.New())
-	indexFlusher.FlushVersion(2, 15, 20, roaring.New())
-	indexFlusher.FlushVersion(3, 22, 24, roaring.New())
+	indexFlusher.FlushVersion(1, timeutil.TimeRange{Start: 12, End: 15}, roaring.New())
+	indexFlusher.FlushVersion(2, timeutil.TimeRange{Start: 15, End: 20}, roaring.New())
+	indexFlusher.FlushVersion(3, timeutil.TimeRange{Start: 22, End: 24}, roaring.New())
 	// flush tagValue2
 	indexFlusher.FlushTagValue("2")
 	// flush tagKeyID

--- a/tsdb/tblstore/inverted_index_merger.go
+++ b/tsdb/tblstore/inverted_index_merger.go
@@ -138,8 +138,7 @@ func (m *invertedIndexMerger) flush(
 			timeRange := data.TimeRange()
 			m.flusher.flushVersion(
 				data.version,
-				uint32(timeRange.Start/1000),
-				uint32(timeRange.End/1000),
+				timeRange,
 				data.bitMapData)
 		}
 		m.flusher.FlushTagValue(tagValue)

--- a/tsdb/tblstore/inverted_index_merger_test.go
+++ b/tsdb/tblstore/inverted_index_merger_test.go
@@ -40,7 +40,7 @@ func buildInvertedIndexBlockToCompact() (data [][]byte) {
 		flusher := NewInvertedIndexFlusher(nopKVFlusher).(*invertedIndexFlusher)
 		for tagValue, versions := range tagValueVersions {
 			for version, bitmap := range versions {
-				flusher.FlushVersion(version, 1, 1, bitmap)
+				flusher.FlushVersion(version, timeutil.TimeRange{Start: 1, End: 1}, bitmap)
 			}
 			flusher.FlushTagValue(tagValue)
 		}

--- a/tsdb/tblstore/inverted_index_reader_test.go
+++ b/tsdb/tblstore/inverted_index_reader_test.go
@@ -53,7 +53,8 @@ func buildInvertedIndexBlock() (zoneBlock []byte, ipBlock []byte, hostBlock []by
 		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.AddMany(ids)
-			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
+			seriesFlusher.FlushVersion(v, timeutil.TimeRange{
+				Start: v.Int64() + 10000*1000, End: v.Int64() + 20000*10000}, bitmap)
 		}
 		seriesFlusher.FlushTagValue(zone)
 	}
@@ -68,7 +69,8 @@ func buildInvertedIndexBlock() (zoneBlock []byte, ipBlock []byte, hostBlock []by
 		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.Add(seriesID)
-			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
+			seriesFlusher.FlushVersion(v, timeutil.TimeRange{
+				Start: v.Int64() + 10000*1000, End: v.Int64() + 20000*10000}, bitmap)
 		}
 		seriesFlusher.FlushTagValue(ip)
 	}
@@ -83,7 +85,8 @@ func buildInvertedIndexBlock() (zoneBlock []byte, ipBlock []byte, hostBlock []by
 		for v := series.Version(1500000000000); v < 1800000000000; v += 100000000000 {
 			bitmap := roaring.New()
 			bitmap.Add(seriesID)
-			seriesFlusher.FlushVersion(v, uint32(v/1000)+10000, uint32(v/1000)+20000, bitmap)
+			seriesFlusher.FlushVersion(v, timeutil.TimeRange{
+				Start: v.Int64() + 10000*1000, End: v.Int64() + 20000*10000}, bitmap)
 		}
 		seriesFlusher.FlushTagValue(host)
 	}


### PR DESCRIPTION
- the immutable of mStore will support only 1 unflushed tagIndex now ;
- remove 2 read-write locks of metric-store, read fieldsMetas and immutable-tagIndex is lock-free now, each read-write lock costs 24 bytes;
- remove hasData flag of tStore, this bool flag is not only useless but also will cost 1 byte per series;
- use the timeutil.TimeRange struct for flushing