### PR TITLE
[feat:#235]: memory statistics of memdb

### DIFF
--- a/storage/runtime.go
+++ b/storage/runtime.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lindb/lindb/pkg/hostutil"
-
 	"github.com/lindb/lindb/config"
 	"github.com/lindb/lindb/constants"
 	"github.com/lindb/lindb/coordinator/discovery"
 	task "github.com/lindb/lindb/coordinator/storage"
 	"github.com/lindb/lindb/models"
 	taskHandler "github.com/lindb/lindb/parallel"
+	"github.com/lindb/lindb/pkg/hostutil"
 	"github.com/lindb/lindb/pkg/logger"
 	"github.com/lindb/lindb/pkg/server"
 	"github.com/lindb/lindb/pkg/state"

--- a/tsdb/memdb/metric_store_index.go
+++ b/tsdb/memdb/metric_store_index.go
@@ -53,7 +53,7 @@ type tagIndexINTF interface {
 		writeCtx writeContext,
 	) (
 		tStore tStoreINTF,
-		writtenSize int,
+		createdSize int,
 		err error)
 
 	// RemoveTStores removes tStores from a list of seriesID
@@ -267,7 +267,7 @@ func (index *tagIndex) GetOrCreateTStore(
 	writeCtx writeContext,
 ) (
 	tStore tStoreINTF,
-	writtenSize int,
+	createdSize int,
 	err error,
 ) {
 	hash := xxhash.Sum64String(tag.Concat(tags))
@@ -279,9 +279,9 @@ func (index *tagIndex) GetOrCreateTStore(
 		if !ok {
 			tStore = newTimeSeriesStore()
 			index.seriesID2TStore.put(seriesID, tStore)
-			writtenSize += tStore.MemSize()
+			createdSize += tStore.MemSize()
 		}
-		return tStore, writtenSize, nil
+		return tStore, createdSize, nil
 	}
 	// seriesID is not allocated before, assign a new one.
 	incrSeriesID := index.idCounter.Inc()
@@ -290,12 +290,12 @@ func (index *tagIndex) GetOrCreateTStore(
 	err = index.insertNewTStore(tags, incrSeriesID, newTStore, writeCtx)
 	if err != nil {
 		index.idCounter.Dec()
-		return nil, writtenSize, err
+		return nil, createdSize, err
 	}
-	writtenSize += newTStore.MemSize()
+	createdSize += newTStore.MemSize()
 	// bind relation of hash and seriesID to the forward index
 	index.hash2SeriesID[hash] = incrSeriesID
-	return newTStore, writtenSize, nil
+	return newTStore, createdSize, nil
 }
 
 // RemoveTStores removes the tStores from seriesIDs

--- a/tsdb/memdb/metric_store_scan_test.go
+++ b/tsdb/memdb/metric_store_scan_test.go
@@ -85,7 +85,7 @@ func Test_MetricStore_scan(t *testing.T) {
 	idGet.EXPECT().GetFieldIDOrGenerate("sum3", gomock.Any(), gomock.Any()).Return(uint16(3), nil)
 	idGet.EXPECT().GetFieldIDOrGenerate("sum4", gomock.Any(), gomock.Any()).Return(uint16(4), nil)
 	bs := newBlockStore(10)
-	err := mStore.Write(metric,
+	writtenSize, err := mStore.Write(metric,
 		writeContext{
 			generator:           generator,
 			blockStore:          bs,
@@ -94,6 +94,7 @@ func Test_MetricStore_scan(t *testing.T) {
 			metricID:            uint32(10),
 			mStoreFieldIDGetter: idGet,
 		})
+	assert.NotZero(t, writtenSize)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
precondition for memory-based flushing strategy

- adjust memory statistics granularity from metric-store to memdb
