### PR TITLE
[feat][pkg:concurrent]: add a recyclable concurrent pool

### DIFF
--- a/config/general.go
+++ b/config/general.go
@@ -55,35 +55,33 @@ type StorageCluster struct {
 
 // Query represents query rpc config
 type Query struct {
-	MaxWorkers int            `toml:"max-workers"`
-	Capacity   int            `toml:"capacity"`
-	Timeout    ltoml.Duration `toml:"timeout"`
+	MaxWorkers  int            `toml:"max-workers"`
+	IdleTimeout ltoml.Duration `toml:"idle-timeout"`
+	Timeout     ltoml.Duration `toml:"timeout"`
 }
 
 func (q *Query) TOML() string {
 	return fmt.Sprintf(`
     ## max concurrentcy number of workers in the executor pool,
     ## each worker is only responsible for execting querying task,
-    ## and free workers will be recycled.
+    ## and idle workers will be recycled.
     max-workers = %d
 
-	## fixed size of tasks queue in the query pool, 
-    ## if the number of unconsumerd tasks' exceeds this capacity,
-    ## the task producer will be blocked
-    capacity = %d
-	
+    ## idle worker will be canceled in this duration
+	idle-timeout = "%s"
+
     ## maximum timeout threshold for the task performed
     timeout = "%s"`,
 		q.MaxWorkers,
-		q.Capacity,
+		q.IdleTimeout,
 		q.Timeout,
 	)
 }
 
 func NewDefaultQuery() *Query {
 	return &Query{
-		MaxWorkers: 30,
-		Capacity:   30,
-		Timeout:    ltoml.Duration(30 * time.Second),
+		MaxWorkers:  30,
+		IdleTimeout: ltoml.Duration(5 * time.Second),
+		Timeout:     ltoml.Duration(30 * time.Second),
 	}
 }

--- a/monitoring/runtime_collector_test.go
+++ b/monitoring/runtime_collector_test.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,7 @@ func Test_NewRuntimeCollector(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, _ := ioutil.ReadAll(r.Body)
-			t.Log(string(data))
+			fmt.Println(string(data))
 		}))
 	defer ts.Close()
 

--- a/monitoring/system_test.go
+++ b/monitoring/system_test.go
@@ -1,6 +1,7 @@
 package monitoring
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestGetMemoryStat(t *testing.T) {
 }
 
 func TestGetDiskStat(t *testing.T) {
-	t.Log(filepath.VolumeName("/tmp/test/test11111"))
+	fmt.Println(filepath.VolumeName("/tmp/test/test11111"))
 	_, err := GetDiskStat("/tmp/test/test111")
 	assert.NotNil(t, err)
 

--- a/parallel/task_handler_test.go
+++ b/parallel/task_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -12,14 +13,15 @@ import (
 
 	"github.com/lindb/lindb/config"
 	"github.com/lindb/lindb/models"
+	"github.com/lindb/lindb/pkg/ltoml"
 	"github.com/lindb/lindb/rpc"
 	pb "github.com/lindb/lindb/rpc/proto/common"
 )
 
 var cfg = config.Query{
-	MaxWorkers: 10,
-	Capacity:   10,
-	Timeout:    10,
+	MaxWorkers:  10,
+	IdleTimeout: ltoml.Duration(time.Second * 5),
+	Timeout:     ltoml.Duration(time.Second * 10),
 }
 
 func TestTaskHandler_Handle(t *testing.T) {

--- a/pkg/concurrent/model.go
+++ b/pkg/concurrent/model.go
@@ -1,0 +1,9 @@
+package concurrent
+
+// PoolStat is the statistics data for pool
+type PoolStat struct {
+	AliveWorkers   int
+	CreatedWorkers int
+	KilledWorkers  int
+	ConsumedTasks  int
+}

--- a/pkg/concurrent/pool.go
+++ b/pkg/concurrent/pool.go
@@ -1,144 +1,232 @@
 package concurrent
 
 import (
-	"go.uber.org/atomic"
+	"context"
+	"sync"
+	"time"
 
-	"github.com/lindb/lindb/pkg/logger"
+	"go.uber.org/atomic"
 )
 
-var log = logger.GetLogger("concurrent", "pool")
+const (
+	// size of the queue that workers register their availability to the dispatcher.
+	readyWorkerQueueSize = 32
+	// size of the tasks queue
+	tasksCapacity = 8
+	// sleeps in this interval when there are no available workers
+	sleepInterval = time.Millisecond * 5
+)
 
 // Task represents a task function to be executed by a worker(goroutine).
 type Task func()
 
 // Pool represents the goroutine pool that executes submitted tasks.
 type Pool interface {
-	// Name returns the name of pool
-	Name() string
-	// Execute executes the given task
-	Execute(task Task)
-	// Shutdown shutdowns all goroutines gracefully
-	Shutdown()
+	// Submit enqueues a callable task for a worker to execute.
+	//
+	// Each submitted task is immediately given to an ready worker.
+	// If there are no available workers, the dispatcher starts a new worker,
+	// until the maximum number of workers are added.
+	//
+	// After the maximum number of workers are running, and no workers are ready,
+	// execute function will be blocked.
+	Submit(task Task)
+	// SubmitAndWait executes the task and waits for it to be executed.
+	SubmitAndWait(task Task)
+	// Stopped returns true if this pool has been stopped.
+	Stopped() bool
+	// Stop stops all goroutines gracefully,
+	// all pending tasks will be finished before exit
+	Stop()
+	// Statistics returns the statistics data since started
+	Statistics() *PoolStat
 }
 
-// pool implements a simple goroutine pool
-type pool struct {
-	name string
-
-	tasks   chan Task
-	workers chan *worker
-	stop    chan struct{}
-
-	closing atomic.Bool
-
-	// pool stats
-	pending   atomic.Int64
-	completed atomic.Int64
-
-	worker atomic.Int64
+// workerPool is a pool for goroutines.
+type workerPool struct {
+	maxWorkers          int
+	tasks               chan Task     // tasks channel
+	readyWorkers        chan *worker  // available worker
+	idleTimeout         time.Duration // idle goroutine recycle time
+	onDispatcherStopped chan struct{} // signal that dispatcher is stopped
+	stopped             atomic.Bool   // mark if the pool is closed or not
+	workersAlive        atomic.Int32  // current workers count in use
+	workersCreated      atomic.Int32  // workers created count since start
+	workersKilled       atomic.Int32  // workers killed since start
+	tasksConsumed       atomic.Int32  // tasks consumed count
+	ctx                 context.Context
+	cancel              context.CancelFunc
 }
 
-// NewPool creates a pool
-func NewPool(name string, maxWorkers int, capacity int) Pool {
-	pool := &pool{
-		name:    name,
-		tasks:   make(chan Task, capacity),
-		workers: make(chan *worker, maxWorkers),
-		stop:    make(chan struct{}),
+// NewPool returns a new worker pool,
+// maxWorkers parameter specifies the maximum number workers that will execute tasks concurrently.
+func NewPool(maxWorkers int, idleTimeout time.Duration) Pool {
+	if maxWorkers < 1 {
+		maxWorkers = 1
 	}
-	pool.worker.Add(int64(maxWorkers))
-	// init worker pool
-	for i := 0; i < maxWorkers; i++ {
-		_ = newWorker(pool)
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &workerPool{
+		maxWorkers:          maxWorkers,
+		tasks:               make(chan Task, tasksCapacity),
+		readyWorkers:        make(chan *worker, readyWorkerQueueSize),
+		idleTimeout:         idleTimeout,
+		onDispatcherStopped: make(chan struct{}),
+		stopped:             *atomic.NewBool(false),
+		workersAlive:        *atomic.NewInt32(0),
+		workersCreated:      *atomic.NewInt32(0),
+		workersKilled:       *atomic.NewInt32(0),
+		tasksConsumed:       *atomic.NewInt32(0),
+		ctx:                 ctx,
+		cancel:              cancel,
 	}
-	// start task dispatch routine
 	go pool.dispatch()
 	return pool
 }
 
-// Name returns the name
-func (p *pool) Name() string {
-	return p.name
+func (p *workerPool) Statistics() *PoolStat {
+	return &PoolStat{
+		AliveWorkers:   int(p.workersAlive.Load()),
+		CreatedWorkers: int(p.workersCreated.Load()),
+		KilledWorkers:  int(p.workersKilled.Load()),
+		ConsumedTasks:  int(p.tasksConsumed.Load())}
 }
 
-// Execute puts the task to queue, if pool is closing reject the task
-func (p *pool) Execute(task Task) {
-	// pool is closing, reject new task
-	if p.closing.Load() {
+func (p *workerPool) Submit(task Task) {
+	if task == nil || p.Stopped() {
 		return
 	}
-	p.pending.Inc()
 	p.tasks <- task
 }
 
-// Shutdown shutdowns all worker goroutines gracefully
-func (p *pool) Shutdown() {
-	if p.closing.Swap(true) {
-		// already closing
+func (p *workerPool) SubmitAndWait(task Task) {
+	if task == nil || p.Stopped() {
 		return
 	}
-	// do shutdown logic
-	p.stop <- struct{}{}
-	<-p.stop
+	worker := p.mustGetWorker()
+	doneChan := make(chan struct{})
+	worker.execute(func() {
+		task()
+		close(doneChan)
+	})
+	<-doneChan
+}
 
-	// process pending tasks, before shutdown
-	completed := make(chan struct{})
-	go func() {
-		for taskFn := range p.tasks {
-			taskFn()
+// mustGetWorker makes sure that a ready worker is return
+func (p *workerPool) mustGetWorker() *worker {
+	var worker *worker
+	for {
+		select {
+		// got a worker
+		case worker = <-p.readyWorkers:
+			return worker
+		default:
+			if int(p.workersAlive.Load()) >= p.maxWorkers {
+				// no available workers
+				time.Sleep(sleepInterval)
+				continue
+			}
+			w := newWorker(p)
+			return w
 		}
-		completed <- struct{}{}
+	}
+}
+
+func (p *workerPool) dispatch() {
+	defer func() {
+		p.onDispatcherStopped <- struct{}{}
 	}()
-	// close tasks chan
-	close(p.tasks)
-	// wait pending task process complete
-	<-completed
+
+	idleTimeoutTimer := time.NewTimer(p.idleTimeout)
+	defer idleTimeoutTimer.Stop()
+	var (
+		worker *worker
+		task   Task
+	)
+
+	for {
+		idleTimeoutTimer.Reset(p.idleTimeout)
+		select {
+		case <-p.ctx.Done():
+			return
+		case task = <-p.tasks:
+			worker := p.mustGetWorker()
+			worker.execute(task)
+		case <-idleTimeoutTimer.C:
+			// timed out waiting, kill a ready worker
+			if p.workersAlive.Load() > 0 {
+				select {
+				case worker = <-p.readyWorkers:
+					worker.stop(func() {})
+				default:
+					// workers are busy now
+				}
+			}
+		}
+	}
 }
 
-// completeTask completes the task
-func (p *pool) completeTask() {
-	p.completed.Inc()
-	p.worker.Inc()
+func (p *workerPool) Stopped() bool {
+	return p.stopped.Load()
 }
 
-// dispatch dispatches the task to free worker
-func (p *pool) dispatch() {
+// stopWorkers stops all workers
+func (p *workerPool) stopWorkers() {
+	var wg sync.WaitGroup
+	for p.workersAlive.Load() > 0 {
+		wg.Add(1)
+		worker := <-p.readyWorkers
+		worker.stop(func() {
+			wg.Done()
+		})
+	}
+	wg.Wait()
+}
+
+// consumedRemainingTasks consumes all buffered tasks in the channel
+func (p *workerPool) consumedRemainingTasks() {
 	for {
 		select {
 		case task := <-p.tasks:
-			// get free worker
-			worker := <-p.workers
-			p.worker.Dec()
-			worker.execute(task)
-			// dec pending after execute
-			p.pending.Dec()
-		case <-p.stop:
-			// shutdown all worker
-			for i := 0; i < cap(p.workers); i++ {
-				worker := <-p.workers
-				worker.shutdown()
-			}
-			p.stop <- struct{}{}
+			task()
+			p.tasksConsumed.Inc()
+		default:
 			return
 		}
 	}
 }
 
-// worker represents the worker that executes the task
-type worker struct {
-	pool *pool
-
-	tasks chan Task
-	stop  chan struct{}
+// Stop tells the dispatcher to exit with pending tasks done.
+func (p *workerPool) Stop() {
+	if p.stopped.Swap(true) {
+		return
+	}
+	// close dispatcher
+	p.cancel()
+	// wait dispatcher's exit
+	<-p.onDispatcherStopped
+	// close all workers
+	p.stopWorkers()
+	// consume remaining tasks
+	p.consumedRemainingTasks()
 }
 
-// newWorker creates the worker and start goroutine
-func newWorker(pool *pool) *worker {
+// worker represents the worker that executes the task
+type worker struct {
+	pool   *workerPool
+	tasks  chan Task
+	stopCh chan struct{}
+}
+
+// newWorker creates the worker that executes tasks given by the dispatcher
+// When a new worker starts, it registers itself on the createdWorkers channel.
+func newWorker(pool *workerPool) *worker {
 	w := &worker{
-		pool:  pool,
-		tasks: make(chan Task),
-		stop:  make(chan struct{}),
+		pool:   pool,
+		tasks:  make(chan Task),
+		stopCh: make(chan struct{}),
 	}
+	w.pool.workersAlive.Inc()
+	w.pool.workersCreated.Inc()
 	go w.process()
 	return w
 }
@@ -148,25 +236,25 @@ func (w *worker) execute(task Task) {
 	w.tasks <- task
 }
 
-// process process task from queue
-func (w *worker) process() {
-	for {
-		w.pool.workers <- w
-		select {
-		case taskFn := <-w.tasks:
-			taskFn()
-			w.pool.completeTask()
-		case <-w.stop:
-			w.stop <- struct{}{}
-			log.Info("worker exist...", logger.String("pool", w.pool.name))
-			return
-		}
-	}
+func (w *worker) stop(callable func()) {
+	defer callable()
+	w.stopCh <- struct{}{}
+	w.pool.workersKilled.Inc()
+	w.pool.workersAlive.Dec()
 }
 
-// shutdown shutdowns the worker goroutine
-func (w *worker) shutdown() {
-	w.stop <- struct{}{}
-	// waiting for goroutine exit
-	<-w.stop
+// process process task from queue
+func (w *worker) process() {
+	var task Task
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case task = <-w.tasks:
+			task()
+			w.pool.tasksConsumed.Inc()
+			// register worker-self to readyWorkers again
+			w.pool.readyWorkers <- w
+		}
+	}
 }

--- a/pkg/concurrent/pool_test.go
+++ b/pkg/concurrent/pool_test.go
@@ -3,35 +3,65 @@ package concurrent
 import (
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 )
 
-func TestPool_Submit(t *testing.T) {
+func Test_Pool_Submit(t *testing.T) {
 	grNum := runtime.NumGoroutine()
-	pool := NewPool("test_pool", 2, 10)
-	assert.Equal(t, "test_pool", pool.Name())
-	// num. of pool + 1 dispatch
-	assert.Equal(t, grNum+2+1, runtime.NumGoroutine())
+	pool := NewPool(2, time.Second*5)
+	// num. of pool + 1 dispatcher, workers has not been spawned
+	assert.Equal(t, grNum+1, runtime.NumGoroutine())
 
 	var c atomic.Int32
-	iterations := 10000
 
-	for i := 0; i < iterations; i++ {
-		pool.Execute(func() {
-			c.Inc()
-		})
+	finished := make(chan struct{})
+	do := func(iterations int) {
+		for i := 0; i < iterations; i++ {
+			pool.Submit(func() {
+				c.Inc()
+			})
+		}
+		finished <- struct{}{}
 	}
-	pool.Shutdown()
-	pool.Shutdown()
+	go do(100)
+	<-finished
+	assert.Equal(t, grNum+2+1, runtime.NumGoroutine())
+	pool.Stop()
+	pool.Stop()
 	// reject all task
-	for i := 0; i < iterations; i++ {
-		pool.Execute(func() {
-			c.Inc()
-		})
-	}
-	assert.Equal(t, int32(iterations), c.Load())
+	go do(100)
+	<-finished
+	assert.Equal(t, int32(100), c.Load())
 	// all goroutines of pool exited
 	assert.Equal(t, grNum, runtime.NumGoroutine())
+}
+
+func Test_Pool_Statistics(t *testing.T) {
+	p := NewPool(0, time.Millisecond*100)
+	s := p.Statistics()
+	assert.Zero(t, s.AliveWorkers)
+	assert.Zero(t, s.CreatedWorkers)
+	assert.Zero(t, s.KilledWorkers)
+	assert.Zero(t, s.ConsumedTasks)
+	for i := 0; i < 10; i++ {
+		p.SubmitAndWait(nil)
+		p.SubmitAndWait(func() {
+		})
+	}
+	s = p.Statistics()
+	assert.Equal(t, 1, s.AliveWorkers)
+	assert.Equal(t, 1, s.CreatedWorkers)
+	assert.Equal(t, 0, s.KilledWorkers)
+	assert.Equal(t, 10, s.ConsumedTasks)
+
+	time.Sleep(time.Second)
+	p.Stop()
+	s = p.Statistics()
+	assert.Equal(t, 0, s.AliveWorkers)
+	assert.Equal(t, 1, s.CreatedWorkers)
+	assert.Equal(t, 1, s.KilledWorkers)
+	assert.Equal(t, 10, s.ConsumedTasks)
 }

--- a/query/scan_worker.go
+++ b/query/scan_worker.go
@@ -57,9 +57,9 @@ func (s *scanWorker) Emit(event series.ScanEvent) {
 		return
 	}
 	s.pending.Inc()
-	s.executorPool.Scanners.Execute(func() {
+	s.executorPool.Scanners.Submit(func() {
 		if event.Scan() {
-			s.executorPool.Mergers.Execute(func() {
+			s.executorPool.Mergers.Submit(func() {
 				defer s.complete()
 
 				resultSet := event.ResultSet()

--- a/query/scan_worker_test.go
+++ b/query/scan_worker_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var execPool = &tsdb.ExecutorPool{
-	Scanners: concurrent.NewPool("test-pool1", 10 /*nRoutines*/, 10 /*queueSize*/),
-	Mergers:  concurrent.NewPool("test-pool2", 10 /*nRoutines*/, 10 /*queueSize*/),
+	Scanners: concurrent.NewPool(10, 10*time.Second),
+	Mergers:  concurrent.NewPool(10, 10*time.Second),
 }
 
 func TestScanWorker_Emit(t *testing.T) {

--- a/query/storage_executor.go
+++ b/query/storage_executor.go
@@ -99,7 +99,7 @@ func (e *storageExecutor) Execute() {
 		shard := e.shards[idx]
 		// execute memory db search in background goroutine
 		e.executeCtx.RetainTask(1)
-		e.executorPool.Scanners.Execute(func() {
+		e.executorPool.Scanners.Submit(func() {
 			e.memoryDBSearch(shard)
 		})
 

--- a/tsdb/database.go
+++ b/tsdb/database.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 
@@ -88,13 +90,11 @@ func newDatabase(
 		numOfShards: *atomic.NewInt32(0),
 		executorPool: &ExecutorPool{
 			Scanners: concurrent.NewPool(
-				databaseName+"-executor-pool",
-				100, /*nRoutines*/
-				10 /*queueSize*/),
+				runtime.NumCPU(), /*nRoutines*/
+				time.Second*5),
 			Mergers: concurrent.NewPool(
-				databaseName+"-executor-pool",
-				100, /*nRoutines*/
-				10 /*queueSize*/),
+				runtime.NumCPU(),
+				time.Second*5),
 		},
 		isFlushing: *atomic.NewBool(false),
 	}


### PR DESCRIPTION
- New a concurrent-pool with idle-timeout config;
- add a SubmitAndWait method for blocking executing task
- remove capacity for the tasks channel, as it's parameter is useless; 
- add a Statistics for the concurrent-pool