### PR TITLE
[feat][coordinator]: flush memory database api for submit coordinator flush task

### DIFF
--- a/broker/api/admin/database_flusher.go
+++ b/broker/api/admin/database_flusher.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/lindb/lindb/broker/api"
+	"github.com/lindb/lindb/coordinator"
+	"github.com/lindb/lindb/pkg/logger"
+)
+
+var adminLogger = logger.GetLogger("broker", "adminAPI")
+var httpGet = http.Get
+
+// DatabaseFlusherAPI represents the memory database flush by manual
+type DatabaseFlusherAPI struct {
+	master coordinator.Master
+}
+
+// NewDatabaseFlusherAPI create database flusher api
+func NewDatabaseFlusherAPI(master coordinator.Master) *DatabaseFlusherAPI {
+	return &DatabaseFlusherAPI{master: master}
+}
+
+// SubmitFlushTask submits the task which does flush job over memory database
+func (df *DatabaseFlusherAPI) SubmitFlushTask(w http.ResponseWriter, r *http.Request) {
+	cluster, err := api.GetParamsFromRequest("cluster", r, "", true)
+	if err != nil {
+		api.Error(w, err)
+		return
+	}
+	databaseName, err := api.GetParamsFromRequest("db", r, "", true)
+	if err != nil {
+		api.Error(w, err)
+		return
+	}
+	if df.master.IsMaster() {
+		// if current node is master, submits the flush task
+		if err := df.master.FlushDatabase(cluster, databaseName); err != nil {
+			api.Error(w, err)
+			return
+		}
+	} else {
+		// if current node is not master, need forward to master node
+		masterNode := df.master.GetMaster().Node
+		resp, err := httpGet(fmt.Sprintf("http://%s:%d"+r.RequestURI, masterNode.IP, masterNode.Port))
+		if resp != nil {
+			if resp.Body != nil {
+				if err := resp.Body.Close(); err != nil {
+					adminLogger.Error("close http response body", logger.Error(err))
+				}
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				api.Error(w, fmt.Errorf("master handle error after forward"))
+				return
+			}
+		}
+		if err != nil {
+			api.Error(w, err)
+			return
+		}
+	}
+	api.OK(w, "success")
+}

--- a/broker/api/admin/database_flusher_test.go
+++ b/broker/api/admin/database_flusher_test.go
@@ -1,0 +1,144 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/lindb/lindb/coordinator"
+	"github.com/lindb/lindb/mock"
+	"github.com/lindb/lindb/models"
+)
+
+type mockIOReader struct {
+}
+
+func (m *mockIOReader) Close() error {
+	return fmt.Errorf("err")
+}
+func (m *mockIOReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("err")
+}
+
+func TestNewDatabaseFlusherAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	master := coordinator.NewMockMaster(ctrl)
+	flushAPI := NewDatabaseFlusherAPI(master)
+
+	// no cluster
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flusher",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusInternalServerError,
+	})
+
+	// no database name
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush?cluster=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusInternalServerError,
+	})
+
+	// submit err
+	master.EXPECT().IsMaster().Return(true)
+	master.EXPECT().FlushDatabase(gomock.Any(), gomock.Any()).Return(fmt.Errorf("err"))
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusInternalServerError,
+	})
+
+	// submit ok
+	master.EXPECT().IsMaster().Return(true)
+	master.EXPECT().FlushDatabase(gomock.Any(), gomock.Any()).Return(nil)
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusOK,
+	})
+
+	defer func() {
+		httpGet = http.Get
+	}()
+
+	// forward master
+	master.EXPECT().IsMaster().Return(false)
+	master.EXPECT().GetMaster().Return(&models.Master{
+		Node: models.Node{
+			IP:   "127.0.0.1",
+			Port: 12345,
+		},
+	})
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return nil, fmt.Errorf("err")
+	}
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusInternalServerError,
+	})
+
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return nil, nil
+	}
+	master.EXPECT().IsMaster().Return(false)
+	master.EXPECT().GetMaster().Return(&models.Master{
+		Node: models.Node{
+			IP:   "127.0.0.1",
+			Port: 12345,
+		},
+	})
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush/ok?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusOK,
+	})
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+		}, nil
+	}
+	master.EXPECT().IsMaster().Return(false)
+	master.EXPECT().GetMaster().Return(&models.Master{
+		Node: models.Node{
+			IP:   "127.0.0.1",
+			Port: 12346,
+		},
+	})
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush/ok?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusInternalServerError,
+	})
+
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       &mockIOReader{},
+		}, nil
+	}
+	master.EXPECT().IsMaster().Return(false)
+	master.EXPECT().GetMaster().Return(&models.Master{
+		Node: models.Node{
+			IP:   "127.0.0.1",
+			Port: 12346,
+		},
+	})
+	mock.DoRequest(t, &mock.HTTPHandler{
+		Method:         http.MethodGet,
+		URL:            "/database/flush/ok?cluster=test&db=test",
+		HandlerFunc:    flushAPI.SubmitFlushTask,
+		ExpectHTTPCode: http.StatusOK,
+	})
+}

--- a/constants/coordinator.go
+++ b/constants/coordinator.go
@@ -40,6 +40,8 @@ const (
 const (
 	// CreateShard represents task kind which is create shard for storage node
 	CreateShard task.Kind = "create-shard"
+	// FlushDatabase represents task kind which is flush memory database for storage node
+	FlushDatabase task.Kind = "flush-database"
 )
 
 // GetStorageClusterConfigPath returns path which storing config of storage cluster

--- a/coordinator/context/master.go
+++ b/coordinator/context/master.go
@@ -14,26 +14,26 @@ type StateMachine struct {
 
 // MasterContext represents master context, creates it after node elect master
 type MasterContext struct {
-	stateMachine *StateMachine
+	StateMachine *StateMachine
 }
 
 // NewMasterContext creates master context using state machine
 func NewMasterContext(stateMachine *StateMachine) *MasterContext {
 	return &MasterContext{
-		stateMachine: stateMachine,
+		StateMachine: stateMachine,
 	}
 }
 
 // Close closes all state machines, releases resource that master used
 func (m *MasterContext) Close() {
 	log := logger.GetLogger("coordinator", "MasterContext")
-	if m.stateMachine.StorageCluster != nil {
-		if err := m.stateMachine.StorageCluster.Close(); err != nil {
+	if m.StateMachine.StorageCluster != nil {
+		if err := m.StateMachine.StorageCluster.Close(); err != nil {
 			log.Error("close storage cluster state machine error", logger.Error(err), logger.Stack())
 		}
 	}
-	if m.stateMachine.DatabaseAdmin != nil {
-		if err := m.stateMachine.DatabaseAdmin.Close(); err != nil {
+	if m.StateMachine.DatabaseAdmin != nil {
+		if err := m.StateMachine.DatabaseAdmin.Close(); err != nil {
 			log.Error("close database admin state machine error", logger.Error(err), logger.Stack())
 		}
 	}

--- a/coordinator/master_test.go
+++ b/coordinator/master_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lindb/lindb/constants"
 	"github.com/lindb/lindb/coordinator/discovery"
+	"github.com/lindb/lindb/coordinator/storage"
 	"github.com/lindb/lindb/models"
 	"github.com/lindb/lindb/pkg/encoding"
 	"github.com/lindb/lindb/pkg/state"
@@ -124,6 +125,59 @@ func TestMaster_Fail(t *testing.T) {
 	assert.Nil(t, master1.GetMaster())
 
 	master1.Stop()
+}
+
+func TestMaster_FlushDatabase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventCh := make(chan *state.Event)
+
+	repo := state.NewMockRepository(ctrl)
+	repo.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	repo.EXPECT().Watch(gomock.Any(), gomock.Any(), true).Return(eventCh).AnyTimes()
+	repo.EXPECT().Elect(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil, nil).AnyTimes()
+	discoveryFactory := discovery.NewMockFactory(ctrl)
+	discovery1 := discovery.NewMockDiscovery(ctrl)
+	discovery1.EXPECT().Discovery().Return(nil).AnyTimes()
+	discovery1.EXPECT().Close().AnyTimes()
+	discoveryFactory.EXPECT().CreateDiscovery(gomock.Any(), gomock.Any()).Return(discovery1).AnyTimes()
+
+	node1 := models.Node{IP: "1.1.1.1", Port: 8000}
+	master1 := NewMaster(&MasterCfg{
+		Ctx:              context.TODO(),
+		Repo:             repo,
+		Node:             node1,
+		TTL:              1,
+		DiscoveryFactory: discoveryFactory,
+	})
+	err := master1.FlushDatabase("test", "test")
+	assert.NoError(t, err)
+
+	master1.Start()
+	data := encoding.JSONMarshal(&models.Master{Node: node1})
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeModify,
+		KeyValues: []state.EventKeyValue{
+			{Key: constants.MasterPath, Value: data},
+		},
+	})
+	assert.True(t, master1.IsMaster())
+	err = master1.FlushDatabase("test", "test")
+	assert.Error(t, err)
+
+	m1 := master1.(*master)
+	m1.mutex.Lock()
+	clusterSM := storage.NewMockClusterStateMachine(ctrl)
+	m1.masterCtx.StateMachine.StorageCluster = clusterSM
+	m1.mutex.Unlock()
+
+	cluster1 := storage.NewMockCluster(ctrl)
+	clusterSM.EXPECT().GetCluster(gomock.Any()).Return(cluster1)
+	cluster1.EXPECT().FlushDatabase(gomock.Any()).Return(nil)
+	err = master1.FlushDatabase("test", "test")
+	assert.NoError(t, err)
 }
 
 func sendEvent(eventCh chan *state.Event, event *state.Event) {

--- a/coordinator/storage/database_flusher_task.go
+++ b/coordinator/storage/database_flusher_task.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/lindb/lindb/constants"
+	"github.com/lindb/lindb/coordinator/task"
+	"github.com/lindb/lindb/models"
+	"github.com/lindb/lindb/pkg/encoding"
+	"github.com/lindb/lindb/pkg/logger"
+	"github.com/lindb/lindb/service"
+)
+
+// databaseFlushProcessor represents flush data of memory database for all shards
+type databaseFlushProcessor struct {
+	storageService service.StorageService
+}
+
+// newCreateShardProcessor returns create shard processor instance
+func newDatabaseFlushProcessor(storageService service.StorageService) task.Processor {
+	return &databaseFlushProcessor{
+		storageService: storageService,
+	}
+}
+
+func (p *databaseFlushProcessor) Kind() task.Kind             { return constants.FlushDatabase }
+func (p *databaseFlushProcessor) RetryCount() int             { return 0 }
+func (p *databaseFlushProcessor) RetryBackOff() time.Duration { return 0 }
+func (p *databaseFlushProcessor) Concurrency() int            { return 1 }
+
+// Process creates shard for storing time series data
+func (p *databaseFlushProcessor) Process(ctx context.Context, task task.Task) error {
+	param := models.DatabaseFlushTask{}
+	if err := encoding.JSONUnmarshal(task.Params, &param); err != nil {
+		return err
+	}
+	r := p.storageService.FlushDatabase(ctx, param.DatabaseName)
+	logger.GetLogger("coordinator", "StorageFlushDBProcessor").
+		Info("process flush memory database data task",
+			logger.String("params", string(task.Params)),
+			logger.Any("result", r),
+		)
+	return nil
+}

--- a/coordinator/storage/database_flusher_task_test.go
+++ b/coordinator/storage/database_flusher_task_test.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lindb/lindb/constants"
+	"github.com/lindb/lindb/coordinator/task"
+	"github.com/lindb/lindb/models"
+	"github.com/lindb/lindb/pkg/encoding"
+	"github.com/lindb/lindb/service"
+)
+
+func TestDatabaseFlushProcessor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	storageService := service.NewMockStorageService(ctrl)
+	processor := newDatabaseFlushProcessor(storageService)
+	assert.Equal(t, 1, processor.Concurrency())
+	assert.Equal(t, time.Duration(0), processor.RetryBackOff())
+	assert.Equal(t, 0, processor.RetryCount())
+	assert.Equal(t, constants.FlushDatabase, processor.Kind())
+
+	err := processor.Process(context.TODO(), task.Task{Params: []byte{1, 1, 1}})
+	assert.NotNil(t, err)
+	param := models.DatabaseFlushTask{}
+	storageService.EXPECT().FlushDatabase(gomock.Any(), gomock.Any()).Return(true)
+	err = processor.Process(context.TODO(), task.Task{Params: encoding.JSONMarshal(&param)})
+	assert.NoError(t, err)
+}

--- a/coordinator/storage/task_executor.go
+++ b/coordinator/storage/task_executor.go
@@ -30,6 +30,7 @@ func NewTaskExecutor(ctx context.Context,
 
 	// register task processor
 	executor.Register(newCreateShardProcessor(storageService))
+	executor.Register(newDatabaseFlushProcessor(storageService))
 	return &TaskExecutor{
 		ctx:            ctx,
 		repo:           repo,

--- a/mock/http_handle.go
+++ b/mock/http_handle.go
@@ -36,6 +36,7 @@ func DoRequest(t *testing.T, httpHandler *HTTPHandler) {
 	}
 	reader := bytes.NewReader(requestBodyBytes)
 	req, err := http.NewRequest(httpHandler.Method, httpHandler.URL, reader)
+	req.RequestURI = httpHandler.URL
 	if err != nil {
 		t.Fatal(err)
 		return

--- a/models/task.go
+++ b/models/task.go
@@ -5,14 +5,24 @@ import (
 	"github.com/lindb/lindb/pkg/option"
 )
 
-// CreateShardTask represents the create shard task param
+// CreateShardTask represents the create shard task's param
 type CreateShardTask struct {
 	DatabaseName   string                `json:"databaseName"`   // database's name
 	ShardIDs       []int32               `json:"shardIDs"`       // shard ids
 	DatabaseOption option.DatabaseOption `json:"databaseOption"` // time series database
 }
 
-// Bytes returns the create shard task binary data using json
+// Bytes returns the create shard task's  binary data using json
 func (t CreateShardTask) Bytes() []byte {
+	return encoding.JSONMarshal(t)
+}
+
+// DatabaseFlushTask represents the database flush task's param
+type DatabaseFlushTask struct {
+	DatabaseName string `json:"databaseName"` // database's name
+}
+
+// Bytes returns the database flush task's binary data using json
+func (t DatabaseFlushTask) Bytes() []byte {
 	return encoding.JSONMarshal(t)
 }

--- a/models/task_test.go
+++ b/models/task_test.go
@@ -20,3 +20,13 @@ func TestCreateShardTask_Bytes(t *testing.T) {
 	_ = json.Unmarshal(data, &task1)
 	assert.Equal(t, task, task1)
 }
+
+func TestDatabaseFlushTask_Bytes(t *testing.T) {
+	task := DatabaseFlushTask{
+		DatabaseName: "test",
+	}
+	data := task.Bytes()
+	task1 := DatabaseFlushTask{}
+	_ = json.Unmarshal(data, &task1)
+	assert.Equal(t, task, task1)
+}

--- a/service/storage.go
+++ b/service/storage.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -26,6 +27,9 @@ type StorageService interface {
 
 	// GetShard returns shard by given db and shard id
 	GetShard(databaseName string, shardID int32) (tsdb.Shard, bool)
+
+	// FLush produces a signal to workers for flushing memory database by name
+	FlushDatabase(ctx context.Context, databaseName string) bool
 }
 
 // storageService implements StorageService interface
@@ -82,4 +86,8 @@ func (s *storageService) GetShard(databaseName string, shardID int32) (tsdb.Shar
 
 func (s *storageService) GetDatabase(databaseName string) (tsdb.Database, bool) {
 	return s.engine.GetDatabase(databaseName)
+}
+
+func (s *storageService) FlushDatabase(ctx context.Context, databaseName string) bool {
+	return s.engine.FlushDatabase(ctx, databaseName)
 }

--- a/service/storage_test.go
+++ b/service/storage_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -62,4 +63,19 @@ func TestCreateShards(t *testing.T) {
 	mockDatabase.EXPECT().CreateShards(gomock.Any(), gomock.Any()).Return(fmt.Errorf("err"))
 	err = service.CreateShards("test_db", validOption, 5)
 	assert.NotNil(t, err)
+}
+
+func TestStorageService_FlushDatabase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer func() {
+		ctrl.Finish()
+		_ = fileutil.RemoveDir(testPath)
+	}()
+
+	mockEngine := tsdb.NewMockEngine(ctrl)
+
+	service := NewStorageService(mockEngine)
+	mockEngine.EXPECT().FlushDatabase(gomock.Any(), gomock.Any()).Return(true)
+	ok := service.FlushDatabase(context.TODO(), "db")
+	assert.True(t, ok)
 }


### PR DESCRIPTION
- add http api in broker side
- master submit flush task
- storage node execute flush task that flushes the memory database's data