### PR TITLE
[feat][query]: scan all metric data from memory database without query filter

### DIFF
--- a/parallel/storage_query_flow_test.go
+++ b/parallel/storage_query_flow_test.go
@@ -71,6 +71,7 @@ func TestStorageQueryFlow_Execute(t *testing.T) {
 	reduceAgg := aggregation.NewMockGroupingAggregator(ctrl)
 	qf.reduceAgg = reduceAgg
 	reduceAgg.EXPECT().ResultSet().Return(nil)
+	reduceAgg.EXPECT().Aggregate(gomock.Any()).AnyTimes()
 
 	var wait sync.WaitGroup
 	wait.Add(6)
@@ -81,8 +82,6 @@ func TestStorageQueryFlow_Execute(t *testing.T) {
 			queryFlow.Scanner(func() {
 				seriesAgg := aggregation.NewMockSeriesAggregator(ctrl)
 				seriesAgg.EXPECT().Reset()
-
-				reduceAgg.EXPECT().Aggregate(gomock.Any())
 
 				queryFlow.Reduce("1.1.1.1", aggregation.FieldAggregates{seriesAgg})
 				wait.Done()
@@ -98,10 +97,10 @@ func TestStorageQueryFlow_Execute(t *testing.T) {
 			})
 		})
 	})
+	wait.Wait()
 	queryFlow.Complete(nil)
 	seriesAgg := aggregation.NewMockSeriesAggregator(ctrl)
 	seriesAgg.EXPECT().Reset()
-	wait.Wait()
 	queryFlow.Reduce("1.1.1.1", aggregation.FieldAggregates{seriesAgg})
 }
 

--- a/query/storage_executor.go
+++ b/query/storage_executor.go
@@ -127,18 +127,19 @@ func (e *storageExecutor) memoryDBSearch(shard tsdb.Shard) {
 func (e *storageExecutor) searchSeriesIDs(filter series.Filter) (seriesIDSet *series.MultiVerSeriesIDSet) {
 	condition := e.query.Condition
 	metricID := e.metricID
+	var err error
 	if condition != nil {
 		seriesSearch := newSeriesSearch(metricID, filter, e.query)
-		idSet, err := seriesSearch.Search()
-		if err != nil {
-			if err != series.ErrNotFound {
-				e.queryFlow.Complete(err)
-			}
-			return
-		}
-		seriesIDSet = idSet
+		seriesIDSet, err = seriesSearch.Search()
+	} else {
+		seriesIDSet, err = filter.GetSeriesIDsForMetric(metricID, e.query.TimeRange)
 	}
-	//TODO add metric level search for no condition
+	if err != nil {
+		if err != series.ErrNotFound {
+			e.queryFlow.Complete(err)
+		}
+		return
+	}
 	return
 }
 

--- a/series/interface.go
+++ b/series/interface.go
@@ -38,4 +38,7 @@ type Filter interface {
 	// GetSeriesIDsForTag get series ids for spec metric's tag key
 	GetSeriesIDsForTag(metricID uint32, tagKey string, timeRange timeutil.TimeRange) (
 		*MultiVerSeriesIDSet, error)
+	// GetSeriesIDsForMetric get series ids for spec metric's id
+	GetSeriesIDsForMetric(metricID uint32, timeRange timeutil.TimeRange) (
+		*MultiVerSeriesIDSet, error)
 }

--- a/tsdb/indexdb/index_database.go
+++ b/tsdb/indexdb/index_database.go
@@ -177,3 +177,27 @@ func (db *indexDatabase) GetSeriesIDsForTag(
 	}
 	return invertedindex.NewReader(readers).GetSeriesIDsForTagKeyID(tagKeyID, timeRange)
 }
+
+// GetSeriesIDsForTag get series ids for spec metric's tag key
+func (db *indexDatabase) GetSeriesIDsForMetric(
+	metricID uint32,
+	timeRange timeutil.TimeRange,
+) (
+	*series.MultiVerSeriesIDSet,
+	error,
+) {
+	//FIXME stone1100 need impl
+	return nil, nil
+	//tagKeyID, err := db.idGetter.GetTagKeyID(metricID, tagKey)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//snapShot := db.invertedIndexFamily.GetSnapshot()
+	//defer snapShot.Close()
+	//
+	//readers, err := snapShot.FindReaders(tagKeyID)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//return invertedindex.NewReader(readers).GetSeriesIDsForTagKeyID(tagKeyID, timeRange)
+}

--- a/tsdb/indexdb/index_database_test.go
+++ b/tsdb/indexdb/index_database_test.go
@@ -191,6 +191,16 @@ func Test_IndexDatabase_GetSeriesIDsForTag(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestIndexDatabase_GetSeriesIDsForMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockedDB := mockIndexDatabase(ctrl)
+
+	set, err := mockedDB.indexDatabase.GetSeriesIDsForMetric(0, timeutil.TimeRange{})
+	assert.Nil(t, set)
+	assert.Nil(t, err)
+}
+
 func buildInvertedIndexBlock() (ipBlock []byte) {
 	nopKVFlusher := kv.NewNopFlusher()
 	seriesFlusher := invertedindex.NewFlusher(nopKVFlusher)

--- a/tsdb/memdb/database.go
+++ b/tsdb/memdb/database.go
@@ -393,6 +393,21 @@ func (md *memoryDatabase) GetSeriesIDsForTag(
 	return mStore.GetSeriesIDsForTag(tagKey)
 }
 
+// GetSeriesIDsForMetric get series ids for spec metric's id from mStore.
+func (md *memoryDatabase) GetSeriesIDsForMetric(
+	metricID uint32,
+	timeRange timeutil.TimeRange,
+) (
+	*series.MultiVerSeriesIDSet,
+	error,
+) {
+	mStore, ok := md.mStores.get(metricID)
+	if !ok {
+		return nil, series.ErrNotFound
+	}
+	return mStore.GetSeriesIDsForMetric(timeRange)
+}
+
 // GetGroupingContext returns the context of group by from memory database
 func (md *memoryDatabase) GetGroupingContext(metricID uint32, tagKeys []string,
 	version series.Version,

--- a/tsdb/memdb/metric_store_index_test.go
+++ b/tsdb/memdb/metric_store_index_test.go
@@ -274,6 +274,32 @@ func Test_tagIndex_getSeriesIDsForTag(t *testing.T) {
 	assert.Equal(t, uint64(8), bitmap.GetCardinality())
 }
 
+func TestTagIndex_GetSeriesIDsForMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tagIdxInterface := newTagIndex()
+	tagIdx := tagIdxInterface.(*tagIndex)
+	// tag no value
+	bitmap := tagIdx.GetSeriesIDsForMetric()
+	assert.Nil(t, bitmap)
+
+	tagIdx.tagKVEntrySet = append(tagIdx.tagKVEntrySet, &tagKVEntrySet{
+		values: map[string]*roaring.Bitmap{
+			"a": roaring.BitmapOf(1),
+			"b": roaring.BitmapOf(2),
+			"c": roaring.BitmapOf(3),
+		},
+	}, &tagKVEntrySet{
+		values: map[string]*roaring.Bitmap{
+			"e": roaring.BitmapOf(1),
+			"f": roaring.BitmapOf(3),
+		},
+	})
+
+	bitmap = tagIdx.GetSeriesIDsForMetric()
+	assert.Equal(t, roaring.BitmapOf(1, 3), bitmap)
+}
+
 type mockTagKey struct {
 }
 


### PR DESCRIPTION
- get metric level all series ids by one tag key which has min tag value count
- scan the data