### PR TITLE
[feat][query]: scan all metric data from data family without query filter

### DIFF
--- a/pkg/encoding/fixed_offset.go
+++ b/pkg/encoding/fixed_offset.go
@@ -67,6 +67,11 @@ func NewFixedOffsetDecoder(buf []byte) *FixedOffsetDecoder {
 	}
 }
 
+// Size returns the size of  offset values
+func (d *FixedOffsetDecoder) Size() int {
+	return (d.length - 1) / d.valueLength
+}
+
 // Get gets the offset value by index, if offset > buffer length or index <0 returns -1
 func (d *FixedOffsetDecoder) Get(index int) int {
 	if index < 0 {

--- a/pkg/encoding/fixed_offset_test.go
+++ b/pkg/encoding/fixed_offset_test.go
@@ -30,6 +30,7 @@ func TestFixedOffsetDecoder_Codec(t *testing.T) {
 	assert.Equal(t, 0, decoder.Get(0))
 	assert.Equal(t, -1, decoder.Get(8))
 	assert.Equal(t, -1, decoder.Get(-8))
+	assert.Equal(t, 8, decoder.Size())
 }
 
 func TestFixedOffsetEncoder_Reset(t *testing.T) {

--- a/tsdb/metadb/interface.go
+++ b/tsdb/metadb/interface.go
@@ -23,6 +23,8 @@ type IDGetter interface {
 	GetMetricID(metricName string) (uint32, error)
 	// GetTagKeyID returns tag ID(uint32), return ErrNotFound if not exist
 	GetTagKeyID(metricID uint32, tagKey string) (tagKeyID uint32, err error)
+	// GetTagKeyIDs returns tag IDs([]uint32), return ErrNotFound if not exist
+	GetTagKeyIDs(metricID uint32) (tagKeyIDs []uint32, err error)
 	// GetFieldID returns field id and type by given metricID and field name,
 	// if not exist return ErrNotFound error
 	GetFieldID(metricID uint32, fieldName string) (fieldID uint16, fieldType field.Type, err error)

--- a/tsdb/tblstore/invertedindex/reader_test.go
+++ b/tsdb/tblstore/invertedindex/reader_test.go
@@ -108,6 +108,19 @@ func buildSeriesIndexReader(ctrl *gomock.Controller) Reader {
 	return NewReader([]table.Reader{mockReader})
 }
 
+func TestReader_GetTagKVEntries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	reader := buildSeriesIndexReader(ctrl)
+	idSet := reader.GetTagKVEntries(uint32(20),
+		timeutil.TimeRange{
+			Start: 1500000000 * 1000,
+			End:   1600000000 * 1000})
+	assert.True(t, idSet.TagValuesCount() > 0)
+	assert.NotNil(t, idSet)
+}
+
 func Test_InvertedIndexReader_GetSeriesIDsForTagID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -247,20 +260,18 @@ func Test_newTagKVEntrySet_error_cases(t *testing.T) {
 func Test_InvertedIndexReader_entrySetToIDSet_error_cases(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	readerIntf := buildSeriesIndexReader(ctrl)
-	readerImpl := readerIntf.(*reader)
 
 	zoneBlock, _, _ := buildInvertedIndexBlock()
 	zoneEntrySet, _ := newTagKVEntrySet(zoneBlock)
 	// first offset not exist
-	idSet, err := readerImpl.entrySetToIDSet(
+	idSet, err := entrySetToIDSet(
 		zoneEntrySet,
 		timeutil.TimeRange{Start: 0, End: math.MaxInt64},
 		[]int{1000, 1200})
 	assert.Nil(t, idSet)
 	assert.NotNil(t, err)
 	// last offset not exist
-	idSet, err = readerImpl.entrySetToIDSet(
+	idSet, err = entrySetToIDSet(
 		zoneEntrySet,
 		timeutil.TimeRange{Start: 0, End: math.MaxInt64},
 		[]int{0, 1200})

--- a/tsdb/tblstore/invertedindex/tagkv_entryset_test.go
+++ b/tsdb/tblstore/invertedindex/tagkv_entryset_test.go
@@ -1,0 +1,42 @@
+package invertedindex
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lindb/lindb/pkg/timeutil"
+	"github.com/lindb/lindb/series"
+)
+
+func TestTagKVEntries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	defer func() {
+		entrySetToIDSetFunc = entrySetToIDSet
+	}()
+
+	entries := TagKVEntries{}
+	assert.Equal(t, 0, entries.TagValuesCount())
+
+	tagKVEntry := NewMockTagKVEntrySetINTF(ctrl)
+	tagKVEntry.EXPECT().TagValuesCount().Return(10)
+	entries = TagKVEntries{tagKVEntry}
+	assert.Equal(t, 10, entries.TagValuesCount())
+
+	entrySetToIDSetFunc = func(entrySet TagKVEntrySetINTF, timeRange timeutil.TimeRange, offsets []int) (idSet *series.MultiVerSeriesIDSet, err error) {
+		return nil, fmt.Errorf("err")
+	}
+	idSet, err := entries.GetSeriesIDs(timeutil.TimeRange{})
+	assert.Error(t, err)
+	assert.Nil(t, idSet)
+
+	entrySetToIDSetFunc = func(entrySet TagKVEntrySetINTF, timeRange timeutil.TimeRange, offsets []int) (idSet *series.MultiVerSeriesIDSet, err error) {
+		return series.NewMultiVerSeriesIDSet(), nil
+	}
+	idSet, err = entries.GetSeriesIDs(timeutil.TimeRange{})
+	assert.NoError(t, err)
+	assert.NotNil(t, idSet)
+}

--- a/tsdb/tblstore/metricsmeta/reader_test.go
+++ b/tsdb/tblstore/metricsmeta/reader_test.go
@@ -58,8 +58,7 @@ func Test_MetricsMetaReader_ok(t *testing.T) {
 	tagID, ok := metaReader.ReadTagKeyID(2, "a2")
 	assert.Equal(t, uint32(7), tagID)
 	assert.True(t, ok)
-	assert.Len(t, metaReader.SuggestTagKeys(2, "a", 100), 2)
-	assert.Len(t, metaReader.SuggestTagKeys(2, "a", 1), 1)
+	assert.Len(t, metaReader.ReadTagKeys(2), 4)
 	// tag not found
 	tagID, ok = metaReader.ReadTagKeyID(2, "a3")
 	assert.Zero(t, tagID)
@@ -96,7 +95,7 @@ func Test_MetricsMetaReader_ReadMaxFieldID(t *testing.T) {
 	data2 = append(data2, byte(32))
 	mockReader2.EXPECT().Get(uint32(2)).Return(data2).Times(2)
 	assert.Equal(t, uint16(0), metaReader.ReadMaxFieldID(2))
-	assert.Nil(t, metaReader.SuggestTagKeys(2, "", 100))
+	assert.Nil(t, metaReader.ReadTagKeys(2))
 }
 
 func Test_MetricsMetaReader_readBlock_corrupt(t *testing.T) {


### PR DESCRIPTION
- load all tag key ids 
- get all series id by tag key id which has min tag values
- scan all metric data