### PR TITLE
[bug]: fix replicator state is empty when create new database

### DIFF
--- a/broker/api/router.go
+++ b/broker/api/router.go
@@ -124,6 +124,7 @@ func panicHandler(h http.Handler) http.Handler {
 					err = errors.New("UnKnow ERROR")
 				}
 				http.Error(w, err.Error(), http.StatusInternalServerError)
+				log.Error("serve http func panic", logger.Error(err), logger.Stack())
 			}
 		}()
 		h.ServeHTTP(w, r)

--- a/coordinator/replica/replicator_state_machine.go
+++ b/coordinator/replica/replicator_state_machine.go
@@ -60,6 +60,8 @@ func NewReplicatorStateMachine(ctx context.Context,
 	for _, shardAssign := range shardAssigns {
 		stateMachine.buildShardAssign(shardAssign)
 	}
+	// final sync new replicator state
+	stateMachine.cm.SyncReplicatorState()
 	// new database's shard assign discovery
 	stateMachine.discovery = discoveryFactory.CreateDiscovery(constants.DatabaseAssignPath, stateMachine)
 	if err := stateMachine.discovery.Discovery(); err != nil {
@@ -79,6 +81,8 @@ func (sm *replicatorStateMachine) OnCreate(key string, resource []byte) {
 	defer sm.mutex.Unlock()
 
 	sm.buildShardAssign(shardAssign)
+	// final sync new replicator state
+	sm.cm.SyncReplicatorState()
 }
 
 // OnDelete trigger on database deletion, destroy related replicators for deletion database

--- a/coordinator/replica/replicator_state_machine_test.go
+++ b/coordinator/replica/replicator_state_machine_test.go
@@ -20,6 +20,7 @@ func TestReplicatorStateMachine(t *testing.T) {
 	defer ctrl.Finish()
 
 	cm := replication.NewMockChannelManager(ctrl)
+	cm.EXPECT().SyncReplicatorState().AnyTimes()
 	shardAssignSRV := service.NewMockShardAssignService(ctrl)
 	discoveryFactory := discovery.NewMockFactory(ctrl)
 	discovery1 := discovery.NewMockDiscovery(ctrl)

--- a/coordinator/state_machine_factory_test.go
+++ b/coordinator/state_machine_factory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lindb/lindb/coordinator/discovery"
 	"github.com/lindb/lindb/models"
 	"github.com/lindb/lindb/pkg/state"
+	"github.com/lindb/lindb/replication"
 	"github.com/lindb/lindb/service"
 )
 
@@ -24,12 +25,15 @@ func TestStateMachineFactory_Create(t *testing.T) {
 	discoveryFactory.EXPECT().CreateDiscovery(gomock.Any(), gomock.Any()).Return(discovery1).AnyTimes()
 	discoveryFactory.EXPECT().GetRepo().Return(repo).AnyTimes()
 	shardAssignSVR := service.NewMockShardAssignService(ctrl)
+	cm := replication.NewMockChannelManager(ctrl)
+	cm.EXPECT().SyncReplicatorState().AnyTimes()
 
 	factory := NewStateMachineFactory(&StateMachineCfg{
 		Ctx:              context.TODO(),
 		CurrentNode:      models.Node{IP: "1.1.1.1", Port: 9000},
 		DiscoveryFactory: discoveryFactory,
 		ShardAssignSRV:   shardAssignSVR,
+		ChannelManager:   cm,
 	})
 
 	// test node state machine

--- a/parallel/context.go
+++ b/parallel/context.go
@@ -116,10 +116,12 @@ func (c *brokerExecuteContext) ResultCh() chan *series.TimeSeriesEvent {
 }
 
 func (c *brokerExecuteContext) ResultSet() (*models.ResultSet, error) {
-	c.resultSet.MetricName = c.query.MetricName
-	c.resultSet.StartTime = c.query.TimeRange.Start
-	c.resultSet.EndTime = c.query.TimeRange.End
-	c.resultSet.Interval = c.query.Interval.Int64()
+	if c.err == nil {
+		c.resultSet.MetricName = c.query.MetricName
+		c.resultSet.StartTime = c.query.TimeRange.Start
+		c.resultSet.EndTime = c.query.TimeRange.End
+		c.resultSet.Interval = c.query.Interval.Int64()
+	}
 	return c.resultSet, c.err
 }
 

--- a/parallel/context_test.go
+++ b/parallel/context_test.go
@@ -99,3 +99,11 @@ func TestBrokerExecuteContext_Emit_GroupBy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, rs.Series, 0)
 }
+
+func TestBrokerExecuteContext_ResultSet(t *testing.T) {
+	ctx := NewBrokerExecuteContext(nil)
+	ctx.Complete(fmt.Errorf("err"))
+	rs, err := ctx.ResultSet()
+	assert.Error(t, err)
+	assert.NotNil(t, rs)
+}

--- a/query/broker_executor.go
+++ b/query/broker_executor.go
@@ -49,7 +49,6 @@ func (e *brokerExecutor) Execute() {
 	storageNodes := e.replicaStateMachine.GetQueryableReplicas(e.database)
 	brokerNodes := e.nodeStateMachine.GetActiveNodes()
 	plan := newBrokerPlan(e.sql, storageNodes, e.nodeStateMachine.GetCurrentNode(), brokerNodes)
-
 	var err error
 	if len(storageNodes) == 0 {
 		err = errNoAvailableStorageNode
@@ -57,6 +56,7 @@ func (e *brokerExecutor) Execute() {
 		err = plan.Plan()
 	}
 
+	// maybe plan doesn't execute(query statement is nil), because storage nodes is empty
 	brokerPlan := plan.(*brokerPlan)
 	e.executeCtx = parallel.NewBrokerExecuteContext(brokerPlan.query)
 


### PR DESCRIPTION
- fix replicator state is empty when create new database
- fix metric query nil point panic when broker execute err, query statement is nil