### PR TITLE
[feat:#307][metadb]: impl id mapping backend storage using bbolt

### DIFF
--- a/constants/errors.go
+++ b/constants/errors.go
@@ -5,4 +5,7 @@ import "errors"
 var (
 	ErrDatabaseNotFound = errors.New("database not found")
 	ErrShardNotFound    = errors.New("shard not found")
+
+	// ErrNotFound represents the data not found
+	ErrNotFound = errors.New("not found")
 )

--- a/tsdb/indexdb/event.go
+++ b/tsdb/indexdb/event.go
@@ -1,0 +1,40 @@
+package indexdb
+
+// seriesEvent represents the series data(tags hash=>series id)
+type seriesEvent struct {
+	tagsHash uint64
+	seriesID uint32
+}
+
+// metricEvent represents metric id mapping include series/metric id sequence
+type metricEvent struct {
+	metricIDSeq uint32
+	events      []seriesEvent
+}
+
+// mappingEvent represents the pending persist id mapping events
+type mappingEvent struct {
+	events map[uint32]*metricEvent
+}
+
+// newMappingEvent creates a id mapping event
+func newMappingEvent() *mappingEvent {
+	return &mappingEvent{
+		events: make(map[uint32]*metricEvent),
+	}
+}
+
+// addSeriesID adds series data for metric
+func (event *mappingEvent) addSeriesID(metricID uint32, tagsHash uint64, seriesID uint32) {
+	e, ok := event.events[metricID]
+	if !ok {
+		e = &metricEvent{}
+		event.events[metricID] = e
+	}
+	e.events = append(e.events, seriesEvent{
+		tagsHash: tagsHash,
+		seriesID: seriesID,
+	})
+	// set id sequence directly, because gen series id in order
+	e.metricIDSeq = seriesID
+}

--- a/tsdb/indexdb/event_test.go
+++ b/tsdb/indexdb/event_test.go
@@ -1,0 +1,20 @@
+package indexdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMappingEvent(t *testing.T) {
+	e := newMappingEvent()
+	e.addSeriesID(1, 10, 100)
+	e.addSeriesID(1, 20, 120)
+	e.addSeriesID(2, 30, 100)
+	e.addSeriesID(2, 40, 200)
+	assert.Len(t, e.events, 2)
+	assert.Equal(t, []seriesEvent{{seriesID: 100, tagsHash: 10}, {seriesID: 120, tagsHash: 20}}, e.events[1].events)
+	assert.Equal(t, uint32(120), e.events[1].metricIDSeq)
+	assert.Equal(t, []seriesEvent{{seriesID: 100, tagsHash: 30}, {seriesID: 200, tagsHash: 40}}, e.events[2].events)
+	assert.Equal(t, uint32(200), e.events[2].metricIDSeq)
+}

--- a/tsdb/indexdb/id_mapping_backend.go
+++ b/tsdb/indexdb/id_mapping_backend.go
@@ -1,0 +1,177 @@
+package indexdb
+
+import (
+	"encoding/binary"
+	"io"
+	"path"
+	"time"
+
+	"github.com/coreos/bbolt"
+
+	"github.com/lindb/lindb/constants"
+	"github.com/lindb/lindb/pkg/fileutil"
+	"github.com/lindb/lindb/pkg/logger"
+)
+
+const MappingDB = "mapping.db"
+
+// for testing
+var (
+	mkDir            = fileutil.MkDirIfNotExist
+	closeFunc        = closeDB
+	setSequenceFunc  = setSequence
+	createBucketFunc = createBucket
+	putFunc          = put
+)
+
+var (
+	seriesBucketName = []byte("s")
+)
+
+// IDMappingBackend represents the id mapping backend storage,
+// save series data(tags hash => series id) under metric
+type IDMappingBackend interface {
+	io.Closer
+	// loadMetricIDMapping loads metric id mapping include id sequence
+	loadMetricIDMapping(metricID uint32) (idMapping MetricIDMapping, err error)
+	// getSeriesID gets series id by metric id/tags hash, if not exist return constants.ErrNotFount
+	getSeriesID(metricID uint32, tagsHash uint64) (seriesID uint32, err error)
+	// saveMapping saves the id mapping event
+	saveMapping(event *mappingEvent) (err error)
+}
+
+// idMappingBackend implements IDMappingBackend interface
+type idMappingBackend struct {
+	db *bbolt.DB
+}
+
+// newIDMappingBackend creates new id mapping backend storage
+func newIDMappingBackend(parent string) (IDMappingBackend, error) {
+	if err := mkDir(parent); err != nil {
+		return nil, err
+	}
+	db, err := bbolt.Open(path.Join(parent, MappingDB), 0600, &bbolt.Options{Timeout: 1 * time.Second, NoSync: true})
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Update(func(tx *bbolt.Tx) error {
+		// create series root bucket for save metric's id mapping
+		_, err := tx.CreateBucketIfNotExists(seriesBucketName)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		// close bbolt.DB if init mapping backend err
+		if e := closeFunc(db); e != nil {
+			indexLogger.Error("close bbolt.db err when create mapping backend fail", logger.Error(e))
+		}
+		return nil, err
+	}
+	return &idMappingBackend{
+		db: db,
+	}, nil
+}
+
+// loadMetricIDMapping loads metric id mapping include id sequence
+func (imb *idMappingBackend) loadMetricIDMapping(metricID uint32) (idMapping MetricIDMapping, err error) {
+	var sequence uint32
+	var scratch [4]byte
+	binary.LittleEndian.PutUint32(scratch[:], metricID)
+	err = imb.db.View(func(tx *bbolt.Tx) error {
+		metricBucket := tx.Bucket(seriesBucketName).Bucket(scratch[:])
+		if metricBucket == nil {
+			return constants.ErrNotFound
+		}
+		sequence = uint32(metricBucket.Sequence())
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newMetricIDMapping(metricID, sequence), nil
+}
+
+// getSeriesID gets series id by metric id/tags hash, if not exist return constants.ErrNotFount
+func (imb *idMappingBackend) getSeriesID(metricID uint32, tagsHash uint64) (seriesID uint32, err error) {
+	var scratch [4]byte
+	binary.LittleEndian.PutUint32(scratch[:], metricID)
+	err = imb.db.View(func(tx *bbolt.Tx) error {
+		metricBucket := tx.Bucket(seriesBucketName).Bucket(scratch[:])
+		if metricBucket == nil {
+			return constants.ErrNotFound
+		}
+		var hash [8]byte
+		binary.LittleEndian.PutUint64(hash[:], tagsHash)
+		value := metricBucket.Get(hash[:])
+		if len(value) == 0 {
+			return constants.ErrNotFound
+		}
+		seriesID = binary.LittleEndian.Uint32(value)
+		return nil
+	})
+	return
+}
+
+// saveMapping saves the id mapping event
+func (imb *idMappingBackend) saveMapping(event *mappingEvent) (err error) {
+	err = imb.db.Update(func(tx *bbolt.Tx) error {
+		for metricID, metricEvent := range event.events {
+			var scratch [4]byte
+			binary.LittleEndian.PutUint32(scratch[:], metricID)
+			id := scratch[:]
+			root := tx.Bucket(seriesBucketName)
+			metricBucket := root.Bucket(id)
+			if metricBucket == nil {
+				// create metric bucket if metric id not exist
+				metricBucket, err = createBucketFunc(root, id)
+				if err != nil {
+					return err
+				}
+			}
+			// save series data
+			for _, seriesEvent := range metricEvent.events {
+				var seriesID [4]byte
+				var hash [8]byte
+				binary.LittleEndian.PutUint64(hash[:], seriesEvent.tagsHash)
+				binary.LittleEndian.PutUint32(seriesID[:], seriesEvent.seriesID)
+				if err = putFunc(metricBucket, hash[:], seriesID[:]); err != nil {
+					return err
+				}
+			}
+			// save metric id sequence
+			if err = setSequenceFunc(metricBucket, uint64(metricEvent.metricIDSeq)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+// Close closes the bbolt.DB
+func (imb *idMappingBackend) Close() error {
+	return imb.db.Close()
+}
+
+// closeDB closes the bbolt.DB
+func closeDB(db *bbolt.DB) error {
+	return db.Close()
+}
+
+// setSequence sets the bucket's sequence
+func setSequence(bucket *bbolt.Bucket, seq uint64) error {
+	return bucket.SetSequence(seq)
+}
+
+// createBucket creates the bucket with name
+func createBucket(parentBucket *bbolt.Bucket, name []byte) (*bbolt.Bucket, error) {
+	return parentBucket.CreateBucket(name)
+}
+
+// put puts the key/value
+func put(bucket *bbolt.Bucket, key, value []byte) error {
+	return bucket.Put(key, value)
+}

--- a/tsdb/indexdb/id_mapping_backend_test.go
+++ b/tsdb/indexdb/id_mapping_backend_test.go
@@ -1,0 +1,135 @@
+package indexdb
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/bbolt"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lindb/lindb/constants"
+	"github.com/lindb/lindb/pkg/fileutil"
+)
+
+const testPath = "test"
+
+func TestIdMappingBackend_new(t *testing.T) {
+	defer func() {
+		_ = fileutil.RemoveDir(testPath)
+		seriesBucketName = []byte("s")
+		closeFunc = closeDB
+		mkDir = fileutil.MkDirIfNotExist
+	}()
+	// case 1: new backend
+	backend, err := newIDMappingBackend(testPath)
+	assert.NoError(t, err)
+	assert.NotNil(t, backend)
+	// case 2: cannot reopen
+	backend2, err := newIDMappingBackend(testPath)
+	assert.Error(t, err)
+	assert.Nil(t, backend2)
+	err = backend.Close()
+	assert.NoError(t, err)
+
+	// case 3: mock create root bucket
+	seriesBucketName = []byte("")
+	backend2, err = newIDMappingBackend(testPath)
+	assert.Error(t, err)
+	assert.Nil(t, backend2)
+	closeFunc = func(db *bbolt.DB) error {
+		return fmt.Errorf("err")
+	}
+	seriesBucketName = []byte("")
+	backend2, err = newIDMappingBackend(testPath)
+	assert.Error(t, err)
+	assert.Nil(t, backend2)
+	// case 4: create parent err
+	mkDir = func(path string) error {
+		return fmt.Errorf("err")
+	}
+	backend, err = newIDMappingBackend(testPath)
+	assert.Error(t, err)
+	assert.Nil(t, backend)
+}
+
+func TestIdMappingBackend_mapping(t *testing.T) {
+	defer func() {
+		_ = fileutil.RemoveDir(testPath)
+	}()
+	backend, err := newIDMappingBackend(filepath.Join(testPath, "test"))
+	assert.NoError(t, err)
+	event := newMappingEvent()
+	event.addSeriesID(1, 20, 200)
+	event.addSeriesID(2, 10, 100)
+	event.addSeriesID(2, 30, 300)
+	err = backend.saveMapping(event)
+	assert.NoError(t, err)
+
+	// case 1: get series
+	seriesID, err := backend.getSeriesID(2, 30)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(300), seriesID)
+	// case 2: metric id not exist
+	seriesID, err = backend.getSeriesID(4, 30)
+	assert.Equal(t, err, constants.ErrNotFound)
+	assert.Equal(t, uint32(0), seriesID)
+	// case 3: series id not exist
+	seriesID, err = backend.getSeriesID(2, 300)
+	assert.Equal(t, err, constants.ErrNotFound)
+	assert.Equal(t, uint32(0), seriesID)
+	// case 4: load mapping not exist
+	mapping, err := backend.loadMetricIDMapping(30)
+	assert.Equal(t, err, constants.ErrNotFound)
+	assert.Nil(t, mapping)
+	// case 5: load mapping not exist
+	mapping, err = backend.loadMetricIDMapping(2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(2), mapping.GetMetricID())
+	mapping1 := mapping.(*metricIDMapping)
+	assert.Equal(t, uint32(300), mapping1.idSequence.Load())
+
+	err = backend.Close()
+	assert.NoError(t, err)
+
+	//reopen
+	backend, _ = newIDMappingBackend(filepath.Join(testPath, "test"))
+	mapping, err = backend.loadMetricIDMapping(2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(2), mapping.GetMetricID())
+	mapping = mapping.(*metricIDMapping)
+	assert.Equal(t, uint32(300), mapping1.idSequence.Load())
+}
+
+func TestIdMappingBackend_save_err(t *testing.T) {
+	defer func() {
+		_ = fileutil.RemoveDir(testPath)
+		setSequenceFunc = setSequence
+		createBucketFunc = createBucket
+		putFunc = put
+	}()
+	backend, err := newIDMappingBackend(testPath)
+	assert.NoError(t, err)
+	event := newMappingEvent()
+	event.addSeriesID(1, 20, 200)
+	event.addSeriesID(2, 10, 100)
+	event.addSeriesID(2, 30, 300)
+	setSequenceFunc = func(bucket *bbolt.Bucket, seq uint64) error {
+		return fmt.Errorf("err")
+	}
+	err = backend.saveMapping(event)
+	assert.Error(t, err)
+
+	setSequenceFunc = setSequence
+	createBucketFunc = func(parentBucket *bbolt.Bucket, name []byte) (bucket *bbolt.Bucket, err error) {
+		return nil, fmt.Errorf("err")
+	}
+	err = backend.saveMapping(event)
+	assert.Error(t, err)
+	createBucketFunc = createBucket
+	putFunc = func(bucket *bbolt.Bucket, key, value []byte) error {
+		return fmt.Errorf("err")
+	}
+	err = backend.saveMapping(event)
+	assert.Error(t, err)
+}

--- a/tsdb/indexdb/memory_database.go
+++ b/tsdb/indexdb/memory_database.go
@@ -41,7 +41,7 @@ func (db *memoryIndexDatabase) GetTimeSeriesID(metricName string,
 			// gen new metric id for new metric id mapping
 			metricID := db.generator.GenMetricID(metricName)
 
-			metricIDMappingINTF = newMetricIDMapping(metricID)
+			metricIDMappingINTF = newMetricIDMapping(metricID, 0)
 			db.metricHash2Index.Store(hash, metricIDMappingINTF)
 		}
 	}

--- a/tsdb/indexdb/metric_id_mapping.go
+++ b/tsdb/indexdb/metric_id_mapping.go
@@ -31,11 +31,11 @@ type metricIDMapping struct {
 }
 
 // newMetricIDMapping returns a new metric id mapping
-func newMetricIDMapping(metricID uint32) MetricIDMapping {
+func newMetricIDMapping(metricID, sequence uint32) MetricIDMapping {
 	return &metricIDMapping{
 		metricID:          metricID,
 		hash2SeriesID:     make(map[uint64]uint32),
-		idSequence:        *atomic.NewUint32(0), // first value is 1
+		idSequence:        *atomic.NewUint32(sequence), // first value is 1
 		maxSeriesIDsLimit: *atomic.NewUint32(constants.DefaultMaxSeriesIDsCount),
 	}
 }

--- a/tsdb/indexdb/metric_id_mapping_test.go
+++ b/tsdb/indexdb/metric_id_mapping_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestMetricIDMapping_GetMetricID(t *testing.T) {
-	idMapping := newMetricIDMapping(10)
+	idMapping := newMetricIDMapping(10, 0)
 	assert.Equal(t, uint32(10), idMapping.GetMetricID())
 }
 
 func TestMetricIDMapping_GetOrCreateSeriesID(t *testing.T) {
-	idMapping := newMetricIDMapping(10)
+	idMapping := newMetricIDMapping(10, 0)
 	seriesID, created := idMapping.GetOrCreateSeriesID(100)
 	assert.Equal(t, uint32(1), seriesID)
 	assert.True(t, created)
@@ -25,7 +25,7 @@ func TestMetricIDMapping_GetOrCreateSeriesID(t *testing.T) {
 }
 
 func TestMetricIDMapping_SetMaxTagsLimit(t *testing.T) {
-	idMapping := newMetricIDMapping(10)
+	idMapping := newMetricIDMapping(10, 0)
 	seriesID, created := idMapping.GetOrCreateSeriesID(100)
 	assert.Equal(t, uint32(1), seriesID)
 	assert.True(t, created)


### PR DESCRIPTION
- impl tags hash => series id backend storage for metric level