### PR TITLE
[fix]: set embedded etcd runtime's logger level to error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,19 +27,11 @@ GOLANGCI_LINT_VERSION ?= "v1.18.0"
 pre-test: ## go generate mock file.
 	go install "./ci/mockgen"
 
-	go list ./... | grep -v '/vendor' |grep -v '/gomock' | xargs go generate
+	go list ./... |grep -v '/gomock' | xargs go generate -v
 	# pb mock is not compatable, so this script is used to mock them via reflect mode
 	# notice: https://github.com/golang/mock/issues/401
 	#         https://github.com/golang/mock/pull/163/files
 	sh rpc/pbmock/mock.sh
-
-	if [[ "$$(uname)" == "Darwin" ]]; then \
-       find . -path vendor -prune -o -type f \( -name '*_mock.go' -o -name '*_mock.pb.go' \) -exec \
-       sed -i '' -e 's#\[x\.#\[#g; s#\]x\.#\]#g; s#\*x\.#\*#g; s#(x\.#(#g; s# x\.# #g; s#x "\."##g' {} +; \
-    else \
-       find . -path vendor -prune -o -type f \( -name '*_mock.go' -o -name '*_mock.pb.go' \) -exec \
-       sed -i 's#\[x\.#\[#g; s#\]x\.#\]#g; s#\*x\.#\*#g; s#(x\.#(#g; s# x\.# #g; s#x "\."##g' {} +; \
-    fi
 
 test: ## Run test cases. (Args: GOLANGCI_LINT_VERSION=latest)
 	if [ ! -e ./bin/golangci-lint ]; then \

--- a/standalone/runtime.go
+++ b/standalone/runtime.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/embed"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/lindb/lindb/broker"
 	"github.com/lindb/lindb/config"
@@ -126,6 +127,9 @@ func (r *runtime) startETCD() error {
 	lcurl, _ := url.Parse(r.cfg.ETCD.URL)
 	cfg.LCUrls = []url.URL{*lcurl}
 	cfg.Dir = r.cfg.ETCD.Dir
+	// always set etcd runtime to error level
+	cfg.LogLevel = zapcore.ErrorLevel.String()
+
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
- disable etcd runtime log output, otherwise it will destroy the lind's logger format;
- gomock works well now, therefore the sed scripts is superfluous;
- go generate with displaying process rate