### PR TITLE
[bug]: fix get wrong data after data compact completed

### DIFF
--- a/tsdb/tblstore/metricsdata/field_reader.go
+++ b/tsdb/tblstore/metricsdata/field_reader.go
@@ -18,6 +18,8 @@ type FieldReader interface {
 	getPrimitiveData(fieldID field.ID, primitiveID field.PrimitiveID) []byte
 	// reset resets the field data for reading
 	reset(buf []byte, position int, start, end uint16)
+	// close closes the reader
+	close()
 }
 
 // fieldReader implements FieldReader
@@ -44,10 +46,12 @@ func newFieldReader(buf []byte, position int, start, end uint16) FieldReader {
 func (r *fieldReader) reset(buf []byte, position int, start, end uint16) {
 	r.start = start
 	r.end = end
+	r.buf = buf
 	r.fieldCount = int(stream.ReadUint16(buf, position))
 	r.fieldOffsets = encoding.NewFixedOffsetDecoder(buf[position+2:])
-	r.buf = buf
+	r.offset = 0
 	r.ok = false
+	r.idx = 0
 	r.completed = false
 }
 
@@ -98,4 +102,9 @@ func (r *fieldReader) nextField() bool {
 	r.offset, r.ok = r.fieldOffsets.Get(r.idx)
 	r.idx++
 	return true
+}
+
+// close marks the reader completed
+func (r *fieldReader) close() {
+	r.completed = true
 }

--- a/tsdb/tblstore/metricsdata/field_reader_test.go
+++ b/tsdb/tblstore/metricsdata/field_reader_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lindb/lindb/kv"
+	"github.com/lindb/lindb/pkg/stream"
+	"github.com/lindb/lindb/series/field"
 )
 
 func TestField_read(t *testing.T) {
@@ -33,23 +37,64 @@ func TestField_read(t *testing.T) {
 	data = fReader.getPrimitiveData(10, 2)
 	assert.True(t, len(data) > 0)
 	// case 5: field(10) = field(10) and pID(3)>pID(2), completed
-	data = fReader.getPrimitiveData(10, 3)
+	data = fReader.getPrimitiveData(20, 3)
 	assert.Nil(t, data)
 	// case 6: after completed return nil
-	data = fReader.getPrimitiveData(10, 2)
+	data = fReader.getPrimitiveData(20, 2)
 	assert.Nil(t, data)
 	// case 7: no fields
 	fReader = newFieldReader([]byte{0, 0, 0}, 0, 5, 5)
 	data = fReader.getPrimitiveData(10, 2)
 	assert.Nil(t, data)
-	// case 8: reset, field(100) > field(10) , completed
-	fReader.reset(block, seriesPos, 5, 5)
-	data = fReader.getPrimitiveData(2, 1)
+}
+
+func TestFieldReader_close(t *testing.T) {
+	block := mockMetricMergeBlock([]uint32{1}, 5, 5)
+	r, err := NewReader("1.sst", block)
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+	scanner := newDataScanner(r)
+	seriesPos := scanner.scan(0, 1)
+	fReader := newFieldReader(block, seriesPos, 5, 5)
+	fReader.close()
+	data := fReader.getPrimitiveData(2, 1)
+	assert.Nil(t, data)
+}
+
+func TestFieldReader_reset(t *testing.T) {
+	block := mockMetricMergeBlock([]uint32{1}, 5, 5)
+	r, err := NewReader("1.sst", block)
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+	scanner := newDataScanner(r)
+	seriesPos := scanner.scan(0, 1)
+	fReader := newFieldReader(block, seriesPos, 5, 5)
+	start, end := fReader.slotRange()
+	assert.Equal(t, uint16(5), start)
+	assert.Equal(t, uint16(5), end)
+	data := fReader.getPrimitiveData(2, 1)
 	assert.True(t, len(data) > 0)
 	data = fReader.getPrimitiveData(10, 2)
 	assert.True(t, len(data) > 0)
-	data = fReader.getPrimitiveData(100, 2)
+	data = fReader.getPrimitiveData(10, 3)
 	assert.Nil(t, data)
+
+	// mock diff field
+	nopKVFlusher := kv.NewNopFlusher()
+	flusher := NewFlusher(nopKVFlusher)
+	flusher.FlushFieldMetas(field.Metas{
+		{ID: 10, Type: field.MinField},
+	})
+	flusher.FlushField(field.Key(stream.ReadUint16([]byte{10, byte(2)}, 0)), []byte{1, 2, 3})
+	flusher.FlushSeries(10)
+	_ = flusher.FlushMetric(uint32(10), start, end)
+	block = nopKVFlusher.Bytes()
+
+	// reset value
+	fReader.reset(block, seriesPos, 15, 15)
+	start, end = fReader.slotRange()
+	assert.Equal(t, uint16(15), start)
+	assert.Equal(t, uint16(15), end)
 	data = fReader.getPrimitiveData(10, 2)
-	assert.Nil(t, data)
+	assert.True(t, len(data) > 0)
 }

--- a/tsdb/tblstore/metricsdata/series_merger_test.go
+++ b/tsdb/tblstore/metricsdata/series_merger_test.go
@@ -22,6 +22,8 @@ func TestSeriesMerger_compact_merge(t *testing.T) {
 	decodeStreams := make([]*encoding.TSDDecoder, 3)
 	reader1 := NewMockFieldReader(ctrl)
 	reader2 := NewMockFieldReader(ctrl)
+	reader1.EXPECT().close().AnyTimes()
+	reader2.EXPECT().close().AnyTimes()
 	readers := []FieldReader{reader1, nil, reader2}
 
 	encodeStream := encoding.NewTSDEncoder(5)
@@ -111,6 +113,8 @@ func TestSeriesMerger_rollup_merge(t *testing.T) {
 	decodeStreams := make([]*encoding.TSDDecoder, 3)
 	reader1 := NewMockFieldReader(ctrl)
 	reader2 := NewMockFieldReader(ctrl)
+	reader1.EXPECT().close().AnyTimes()
+	reader2.EXPECT().close().AnyTimes()
 	readers := []FieldReader{reader1, reader2, nil}
 
 	encodeStream := encoding.NewTSDEncoder(5)


### PR DESCRIPTION
- miss reset field reader context for reusing
- maybe field data not exist in current series merge context, but exist in pervious merge context, some field data will read duplicate