### PR TITLE
[bug]: fix watch wrong alive node when broker startup(master elect not complete)

### DIFF
--- a/app/broker/runtime_test.go
+++ b/app/broker/runtime_test.go
@@ -26,20 +26,29 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 
 	"github.com/lindb/lindb/config"
+	"github.com/lindb/lindb/coordinator"
 	brokerpkg "github.com/lindb/lindb/coordinator/broker"
 	"github.com/lindb/lindb/coordinator/discovery"
-	"github.com/lindb/lindb/internal/mock"
+	"github.com/lindb/lindb/internal/concurrent"
 	"github.com/lindb/lindb/internal/server"
+	"github.com/lindb/lindb/models"
+	"github.com/lindb/lindb/monitoring"
 	"github.com/lindb/lindb/pkg/hostutil"
-	"github.com/lindb/lindb/pkg/ltoml"
+	"github.com/lindb/lindb/pkg/http"
+	"github.com/lindb/lindb/pkg/logger"
 	"github.com/lindb/lindb/pkg/state"
+	brokerQuery "github.com/lindb/lindb/query/broker"
+	"github.com/lindb/lindb/replica"
+	"github.com/lindb/lindb/rpc"
+	"github.com/lindb/lindb/series/tag"
 )
 
 var cfg = config.Broker{
 	Monitor: config.Monitor{
-		ReportInterval: ltoml.Duration(10 * time.Second),
+		ReportInterval: 0,
 	},
 	Coordinator: config.RepoState{
 		Namespace: "/test/",
@@ -53,122 +62,323 @@ var cfg = config.Broker{
 		},
 	}}
 
-func TestBrokerRun(t *testing.T) {
-	cluster := mock.StartEtcdCluster(t, "http://localhost:8200")
-	defer cluster.Terminate(t)
-
-	cfg.Coordinator.Endpoints = cluster.Endpoints
-	cfg.Coordinator.Timeout = ltoml.Duration(time.Second * 10)
-	cfg.BrokerBase.HTTP.Port = 9876
-
-	broker := NewBrokerRuntime("test-version", &cfg, true)
-	err := broker.Run()
-	assert.NoError(t, err)
-	// wait run finish
-	time.Sleep(500 * time.Millisecond)
-
-	assert.Equal(t, server.Running, broker.State())
-	assert.Equal(t, "broker", broker.Name())
-
-	broker.Stop()
-	assert.Equal(t, server.Terminated, broker.State())
-}
-
-func TestBrokerRun_GetHost_Err(t *testing.T) {
-	cluster := mock.StartEtcdCluster(t, "http://localhost:8201")
-	defer cluster.Terminate(t)
-
+func TestBrokerRuntime_New(t *testing.T) {
 	defer func() {
-		getHostIP = hostutil.GetHostIP
-		hostName = os.Hostname
+		newRepositoryFactory = state.NewRepositoryFactory
 	}()
-	cfg.Coordinator.Endpoints = cluster.Endpoints
-	cfg.BrokerBase.HTTP.Port = 9875
-
-	broker := NewBrokerRuntime("test-version", &cfg, false)
-	getHostIP = func() (string, error) {
-		return "ip1", fmt.Errorf("err")
+	newRepositoryFactory = func(owner string) state.RepositoryFactory {
+		return nil
 	}
-	err := broker.Run()
-	assert.Error(t, err)
-
-	getHostIP = func() (string, error) {
-		return "ip2", nil
-	}
-	hostName = func() (string, error) {
-		return "host", fmt.Errorf("err")
-	}
-	cfg.BrokerBase.HTTP.Port = 9874
-	broker = NewBrokerRuntime("test-version", &cfg, false)
-	err = broker.Run()
-	assert.NoError(t, err)
-
-	broker.Stop()
-	assert.Equal(t, server.Terminated, broker.State())
+	r := NewBrokerRuntime("version", &cfg, false)
+	assert.NotNil(t, r)
+	assert.Equal(t, "broker", r.Name())
 }
 
-func TestBroker_Run_Err(t *testing.T) {
-	cluster := mock.StartEtcdCluster(t, "http://localhost:8202")
-	defer cluster.Terminate(t)
-
+func TestBrokerRuntime_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	defer func() {
-		newStateMachineFactory = brokerpkg.NewStateMachineFactory
-		newRegistry = discovery.NewRegistry
-		if err := recover(); err != nil {
-			assert.NotNil(t, err)
-		}
-	}()
-	smFct := discovery.NewMockStateMachineFactory(ctrl)
-	smFct.EXPECT().Stop().AnyTimes()
-
-	newStateMachineFactory = func(ctx context.Context,
-		discoveryFactory discovery.Factory,
-		stateMgr brokerpkg.StateManager,
-	) discovery.StateMachineFactory {
-		return smFct
-	}
-	cfg.Coordinator.Endpoints = cluster.Endpoints
-	cfg.BrokerBase.HTTP.Port = 9873
-
-	broker := NewBrokerRuntime("test-version", &cfg, false)
-	b := broker.(*runtime)
-	repoFactory := state.NewMockRepositoryFactory(ctrl)
-	b.repoFactory = repoFactory
-	repoFactory.EXPECT().CreateBrokerRepo(gomock.Any()).Return(nil, fmt.Errorf("err"))
-	err := broker.Run()
-	assert.Error(t, err)
-	broker.Stop()
-
+	repoFct := state.NewMockRepositoryFactory(ctrl)
 	repo := state.NewMockRepository(ctrl)
-	repo.EXPECT().Close().Return(fmt.Errorf("err")).AnyTimes()
-	repoFactory.EXPECT().CreateBrokerRepo(gomock.Any()).Return(repo, nil).AnyTimes()
-
-	broker = NewBrokerRuntime("test-version", &cfg, false)
-	b = broker.(*runtime)
-	b.repoFactory = repoFactory
-	smFct.EXPECT().Start().Return(fmt.Errorf("err"))
-	err = broker.Run()
-	// wait run finish
-	time.Sleep(500 * time.Millisecond)
-	assert.Error(t, err)
-	broker.Stop()
-
-	broker = NewBrokerRuntime("test-version", &cfg, false)
-	b = broker.(*runtime)
-	b.repoFactory = repoFactory
-	smFct.EXPECT().Start().Return(nil)
-	registry := discovery.NewMockRegistry(ctrl)
-	registry.EXPECT().Close().Return(fmt.Errorf("err"))
-	newRegistry = func(repo state.Repository, ttl time.Duration) discovery.Registry {
-		return registry
+	cases := []struct {
+		name    string
+		prepare func()
+		wantErr bool
+	}{
+		{
+			name: "get host ip failure",
+			prepare: func() {
+				getHostIP = func() (string, error) {
+					return "", fmt.Errorf("err")
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "get host name/create state repo failure",
+			prepare: func() {
+				hostName = func() (name string, err error) {
+					return "", fmt.Errorf("err")
+				}
+				repoFct.EXPECT().CreateBrokerRepo(gomock.Any()).Return(nil, fmt.Errorf("err"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "create master controller failure",
+			prepare: func() {
+				mockGrpcServer(ctrl)
+				repoFct.EXPECT().CreateBrokerRepo(gomock.Any()).Return(repo, nil)
+				newMasterController = func(cfg *coordinator.MasterCfg) (coordinator.MasterController, error) {
+					return nil, fmt.Errorf("err")
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "registry alive node failure",
+			prepare: func() {
+				repoFct.EXPECT().CreateBrokerRepo(gomock.Any()).Return(repo, nil)
+				registry := discovery.NewMockRegistry(ctrl)
+				registry.EXPECT().Register(gomock.Any()).Return(fmt.Errorf("err"))
+				newRegistry = func(repo state.Repository, prefixPath string, ttl time.Duration) discovery.Registry {
+					return registry
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "broker state machine start failure, after master election",
+			prepare: func() {
+				repoFct.EXPECT().CreateBrokerRepo(gomock.Any()).Return(repo, nil)
+				registry := discovery.NewMockRegistry(ctrl)
+				registry.EXPECT().Register(gomock.Any()).Return(nil)
+				newRegistry = func(repo state.Repository, prefixPath string, ttl time.Duration) discovery.Registry {
+					return registry
+				}
+				mc := coordinator.NewMockMasterController(ctrl)
+				newMasterController = func(cfg *coordinator.MasterCfg) (coordinator.MasterController, error) {
+					return mc, nil
+				}
+				mc.EXPECT().WatchMasterElected(gomock.Any()).DoAndReturn(func(fn func(_ *models.Master)) {
+					fn(&models.Master{})
+				})
+				mc.EXPECT().Start()
+				smFct := discovery.NewMockStateMachineFactory(ctrl)
+				smFct.EXPECT().Start().Return(fmt.Errorf("err"))
+				newStateMachineFactory = func(ctx context.Context, discoveryFactory discovery.Factory,
+					stateMgr brokerpkg.StateManager) discovery.StateMachineFactory {
+					return smFct
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "broker successfully",
+			prepare: func() {
+				repoFct.EXPECT().CreateBrokerRepo(gomock.Any()).Return(repo, nil)
+				registry := discovery.NewMockRegistry(ctrl)
+				registry.EXPECT().Register(gomock.Any()).Return(nil)
+				newRegistry = func(repo state.Repository, prefixPath string, ttl time.Duration) discovery.Registry {
+					return registry
+				}
+				mc := coordinator.NewMockMasterController(ctrl)
+				newMasterController = func(cfg *coordinator.MasterCfg) (coordinator.MasterController, error) {
+					return mc, nil
+				}
+				mc.EXPECT().WatchMasterElected(gomock.Any()).DoAndReturn(func(fn func(_ *models.Master)) {
+					fn(&models.Master{})
+				})
+				mc.EXPECT().Start()
+				smFct := discovery.NewMockStateMachineFactory(ctrl)
+				smFct.EXPECT().Start().Return(nil)
+				newStateMachineFactory = func(ctx context.Context, discoveryFactory discovery.Factory,
+					stateMgr brokerpkg.StateManager) discovery.StateMachineFactory {
+					return smFct
+				}
+			},
+			wantErr: false,
+		},
 	}
-	registry.EXPECT().Register(gomock.Any()).Return(fmt.Errorf("err"))
-	err = broker.Run()
-	assert.Error(t, err)
-	// wait run finish
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				getHostIP = hostutil.GetHostIP
+				hostName = os.Hostname
+				newGRPCServer = rpc.NewGRPCServer
+				newTaskClientFactory = rpc.NewTaskClientFactory
+				newStateManager = brokerpkg.NewStateManager
+				newChannelManager = replica.NewChannelManager
+				newTaskManager = brokerQuery.NewTaskManager
+				newMasterController = coordinator.NewMasterController
+				newRegistry = discovery.NewRegistry
+				serveGRPCFn = serveGRPC
+
+				newNativeProtoPusher = monitoring.NewNativeProtoPusher
+				newStateMachineFactory = brokerpkg.NewStateMachineFactory
+			}()
+
+			r := &runtime{
+				ctx:                 context.TODO(),
+				enableSystemMonitor: true,
+				config:              &cfg,
+				repoFactory:         repoFct,
+				log:                 logger.GetLogger("runtime", "test"),
+			}
+			resetNewDepsMock()
+			if tt.prepare != nil {
+				tt.prepare()
+			}
+			err := r.Run()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				assert.Equal(t, server.Failed, r.State())
+			} else {
+				assert.Equal(t, server.Running, r.State())
+			}
+		})
+	}
+}
+
+func TestBrokerRuntime_Stop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pusher := monitoring.NewMockNativePusher(ctrl)
+	httpServer := http.NewMockServer(ctrl)
+	registry := discovery.NewMockRegistry(ctrl)
+	mc := coordinator.NewMockMasterController(ctrl)
+	smFct := discovery.NewMockStateMachineFactory(ctrl)
+	repo := state.NewMockRepository(ctrl)
+	stateMgr := brokerpkg.NewMockStateManager(ctrl)
+	connectionMgr := rpc.NewMockConnectionManager(ctrl)
+	channelMgr := replica.NewMockChannelManager(ctrl)
+	grpcServer := rpc.NewMockGRPCServer(ctrl)
+
+	cases := []struct {
+		name    string
+		prepare func()
+	}{
+		{
+			name: "stop failure",
+			prepare: func() {
+				pusher.EXPECT().Stop()
+				httpServer.EXPECT().Close(gomock.Any()).Return(fmt.Errorf("err"))
+				registry.EXPECT().Close().Return(fmt.Errorf("err"))
+				mc.EXPECT().Stop()
+				smFct.EXPECT().Stop()
+				repo.EXPECT().Close().Return(fmt.Errorf("err"))
+				stateMgr.EXPECT().Close()
+				connectionMgr.EXPECT().Close().Return(fmt.Errorf("err"))
+				channelMgr.EXPECT().Close()
+				grpcServer.EXPECT().Stop()
+			},
+		},
+		{
+			name: "stop successfully",
+			prepare: func() {
+				pusher.EXPECT().Stop()
+				httpServer.EXPECT().Close(gomock.Any()).Return(nil)
+				registry.EXPECT().Close().Return(nil)
+				mc.EXPECT().Stop()
+				smFct.EXPECT().Stop()
+				repo.EXPECT().Close().Return(nil)
+				stateMgr.EXPECT().Close()
+				connectionMgr.EXPECT().Close().Return(nil)
+				channelMgr.EXPECT().Close()
+				grpcServer.EXPECT().Stop()
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			r := &runtime{
+				ctx:                 ctx,
+				cancel:              cancel,
+				pusher:              pusher,
+				httpServer:          httpServer,
+				registry:            registry,
+				master:              mc,
+				stateMachineFactory: smFct,
+				repo:                repo,
+				stateMgr:            stateMgr,
+				srv: srv{
+					channelManager: channelMgr,
+				},
+				factory: factory{
+					connectionMgr: connectionMgr,
+				},
+				grpcServer: grpcServer,
+				log:        logger.GetLogger("runtime", "test"),
+			}
+			if tt.prepare != nil {
+				tt.prepare()
+			}
+			r.Stop()
+			assert.Equal(t, server.Terminated, r.State())
+		})
+	}
+}
+
+func TestBrokerRuntime_startGrpcServer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	grpcServer := rpc.NewMockGRPCServer(ctrl)
+	grpcServer.EXPECT().Start().Return(fmt.Errorf("err"))
+	assert.Panics(t, func() {
+		serveGRPC(grpcServer)
+	})
+}
+
+func TestBrokerRuntime_push_metric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer func() {
+		newNativeProtoPusher = monitoring.NewNativeProtoPusher
+		ctrl.Finish()
+	}()
+
+	pusher := monitoring.NewMockNativePusher(ctrl)
+	newNativeProtoPusher = func(ctx context.Context, endpoint string,
+		interval time.Duration, pushTimeout time.Duration,
+		globalKeyValues tag.Tags) monitoring.NativePusher {
+		return pusher
+	}
+	r := &runtime{
+		log: logger.GetLogger("runtime", "test"),
+		config: &config.Broker{Monitor: config.Monitor{
+			ReportInterval: 10,
+		}},
+	}
+	pusher.EXPECT().Start().AnyTimes()
+	r.nativePusher()
 	time.Sleep(500 * time.Millisecond)
-	broker.Stop()
+}
+
+func resetNewDepsMock() {
+	newStateManager = func(ctx context.Context, currentNode models.StatelessNode,
+		connectionManager rpc.ConnectionManager,
+		taskClientFactory rpc.TaskClientFactory) brokerpkg.StateManager {
+		return nil
+	}
+	newChannelManager = func(ctx context.Context, fct rpc.ClientStreamFactory,
+		stateMgr brokerpkg.StateManager) replica.ChannelManager {
+		return nil
+	}
+	newTaskManager = func(ctx context.Context, currentNode models.Node,
+		taskClientFactory rpc.TaskClientFactory, taskServerFactory rpc.TaskServerFactory,
+		taskPool concurrent.Pool, ttl time.Duration) brokerQuery.TaskManager {
+		return nil
+	}
+	newMasterController = func(cfg *coordinator.MasterCfg) (coordinator.MasterController, error) {
+		return nil, nil
+	}
+	newRegistry = func(repo state.Repository, prefixPath string, ttl time.Duration) discovery.Registry {
+		return nil
+	}
+	serveGRPCFn = func(grpc rpc.GRPCServer) {
+	}
+	newStateMachineFactory = func(ctx context.Context, discoveryFactory discovery.Factory,
+		stateMgr brokerpkg.StateManager) discovery.StateMachineFactory {
+		return nil
+	}
+	newNativeProtoPusher = func(ctx context.Context, endpoint string, interval time.Duration,
+		pushTimeout time.Duration, globalKeyValues tag.Tags) monitoring.NativePusher {
+		return nil
+	}
+}
+
+func mockGrpcServer(ctrl *gomock.Controller) {
+	grpcServer := rpc.NewMockGRPCServer(ctrl)
+	grpcServer.EXPECT().GetServer().Return(grpc.NewServer())
+	newGRPCServer = func(cfg config.GRPC) rpc.GRPCServer {
+		return grpcServer
+	}
 }

--- a/app/storage/runtime.go
+++ b/app/storage/runtime.go
@@ -82,7 +82,7 @@ type runtime struct {
 	config  *config.Storage
 
 	delayInit   time.Duration
-	initializer *bootstrap.ClusterInitializer
+	initializer bootstrap.ClusterInitializer
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -100,7 +100,7 @@ type runtime struct {
 	factory         factory
 	engine          tsdb.Engine
 	rpcHandler      *rpcHandler
-	httpServer      *httppkg.Server
+	httpServer      httppkg.Server
 	queryPool       concurrent.Pool
 	pusher          monitoring.NativePusher
 	globalKeyValues tag.Tags

--- a/constants/coordinator.go
+++ b/constants/coordinator.go
@@ -32,15 +32,14 @@ const (
 const (
 	// LiveNodesPath represents live nodes prefix path for node register.
 	LiveNodesPath = "/live/nodes"
-	// StateNodesPath represents the state of node that node will report runtime status
-	//TODO need remove
-	StateNodesPath = "/state/nodes"
 )
 
 // defines broker level constants will be used in broker.
 const (
 	// MasterPath represents master elect path.
 	MasterPath = "/master/node"
+	// MasterElectedPath represents register path after master finished election.
+	MasterElectedPath = "/master/elected"
 	// DatabaseConfigPath represents database config path.
 	DatabaseConfigPath = "/database/config"
 	// ShardAssigmentPath represents database shard assignment.
@@ -73,9 +72,4 @@ func GetDatabaseAssignPath(name string) string {
 // GetLiveNodePath returns live node register path.
 func GetLiveNodePath(node string) string {
 	return fmt.Sprintf("%s/%s", LiveNodesPath, node)
-}
-
-// GetNodeMonitoringStatPath returns the node monitoring stat's path
-func GetNodeMonitoringStatPath(node string) string {
-	return fmt.Sprintf("%s/%s", StateNodesPath, node)
 }

--- a/constants/coordinator_test.go
+++ b/constants/coordinator_test.go
@@ -39,7 +39,3 @@ func TestGetStorageClusterConfigPath(t *testing.T) {
 	assert.Equal(t, StorageConfigPath+"/name", GetStorageClusterConfigPath("name"))
 
 }
-
-func TestGetNodeMonitoringStatPath(t *testing.T) {
-	assert.Equal(t, StateNodesPath+"/1.1.1.1:port", GetNodeMonitoringStatPath("1.1.1.1:port"))
-}

--- a/coordinator/discovery/registry_test.go
+++ b/coordinator/discovery/registry_test.go
@@ -36,7 +36,7 @@ func TestRegistry(t *testing.T) {
 
 	repo := state.NewMockRepository(ctrl)
 
-	registry1 := NewRegistry(repo, 100)
+	registry1 := NewRegistry(repo, constants.LiveNodesPath, 100)
 
 	closedCh := make(chan state.Closed)
 
@@ -65,14 +65,14 @@ func TestRegistry(t *testing.T) {
 	err = registry1.Close()
 	assert.NoError(t, err)
 
-	registry1 = NewRegistry(repo, 100)
+	registry1 = NewRegistry(repo, constants.LiveNodesPath, 100)
 	err = registry1.Close()
 	assert.NoError(t, err)
 
 	r := registry1.(*registry)
 	r.register("/data/pant", &node)
 
-	registry1 = NewRegistry(repo, 100)
+	registry1 = NewRegistry(repo, constants.LiveNodesPath, 100)
 	r = registry1.(*registry)
 
 	// cancel ctx in timer

--- a/coordinator/elect/election.go
+++ b/coordinator/elect/election.go
@@ -125,7 +125,7 @@ func (e *election) GetMaster() *models.Master {
 	return nil
 }
 
-// elect elects master, start elect loop for retry when failure
+// elect master, start elect loop for retry when failure
 func (e *election) elect() {
 	for {
 		if e.ctx.Err() != nil {

--- a/monitoring/native_pusher.go
+++ b/monitoring/native_pusher.go
@@ -31,6 +31,8 @@ import (
 	"github.com/lindb/lindb/series/tag"
 )
 
+//go:generate mockgen -source ./native_pusher.go -destination=./native_pusher_mock.go -package=monitoring
+
 var nativePushLogger = logger.GetLogger("monitoring", "Pusher")
 
 var (


### PR DESCRIPTION
get wrong alive node when broker startup, because maybe master elect not complete.