### PR TITLE
[bug]: reset ack/replica index when lost data or consume group ack

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -36,6 +36,7 @@ import (
 var (
 	mkDirFunc          = fileutil.MkDirIfNotExist
 	newPageFactoryFunc = page.NewFactory
+	existFunc          = fileutil.Exist
 )
 
 var (
@@ -456,7 +457,8 @@ func (q *queue) validateSequence(sequence int64) error {
 	defer q.rwMutex.RUnlock()
 
 	if sequence > q.appendedSeq.Load() || sequence <= q.acknowledgedSeq.Load() {
-		return ErrOutOfSequenceRange
+		return fmt.Errorf("%w: get %d, range [%d~%d]", ErrOutOfSequenceRange,
+			sequence, q.appendedSeq.Load(), q.acknowledgedSeq.Load())
 	}
 
 	return nil

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -18,6 +18,7 @@
 package queue
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -116,7 +117,7 @@ func TestQueue_Ack(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		data, err = q.Get(int64(i))
-		assert.Equal(t, ErrOutOfSequenceRange, err)
+		assert.True(t, errors.Is(err, ErrOutOfSequenceRange))
 		assert.Nil(t, data)
 	}
 	q.Close()

--- a/replica/replicator_local.go
+++ b/replica/replicator_local.go
@@ -59,12 +59,14 @@ func NewLocalReplicator(channel *ReplicatorChannel, shard tsdb.Shard, family tsd
 	// add ack sequence callback
 	family.AckSequence(lr.leader, func(seq int64) {
 		lr.SetAckIndex(seq)
-		lr.ResetReplicaIndex(seq + 1) // reset replica index = ack index + 1
 		lr.statistics.AckSequence.Incr()
 		lr.logger.Info("ack local replica index",
 			logger.String("replicator", lr.String()),
 			logger.Int64("ackIdx", seq))
 	})
+
+	// reset replica index = ack index + 1, replay wal log
+	lr.ResetReplicaIndex(lr.AckIndex() + 1)
 
 	lr.logger.Info("start local replicator", logger.String("replica", lr.String()),
 		logger.Int64("replicaIndex", lr.channel.ConsumerGroup.ConsumedSeq()),

--- a/replica/replicator_local_test.go
+++ b/replica/replicator_local_test.go
@@ -80,6 +80,7 @@ func TestLocalReplicator_Replica(t *testing.T) {
 	family.EXPECT().AckSequence(gomock.Any(), gomock.Any()).AnyTimes()
 	q := queue.NewMockConsumerGroup(ctrl)
 	q.EXPECT().ConsumedSeq().Return(int64(10)).AnyTimes()
+	q.EXPECT().SetConsumedSeq(gomock.Any()).AnyTimes()
 	q.EXPECT().Pending().Return(int64(10)).AnyTimes()
 	q.EXPECT().AcknowledgedSeq().Return(int64(0)).AnyTimes()
 	q.EXPECT().Ack(gomock.Any()).AnyTimes()

--- a/replica/replicator_peer.go
+++ b/replica/replicator_peer.go
@@ -166,7 +166,7 @@ func (r *replicatorRunner) replica(_ context.Context) {
 				r.statistics.ConsumeMessageFailures.Incr()
 				r.logger.Warn("cannot get replica message data",
 					logger.String("replicator", r.replicator.String()),
-					logger.Int64("index", seq))
+					logger.Int64("index", seq), logger.Error(err))
 			} else {
 				r.statistics.ConsumeMessage.Incr()
 				r.replicator.Replica(seq, data)


### PR DESCRIPTION
- reset replica index use ack index when data family data lost;
- reset consume group ack use ack of queue when consume group ack lost;