### PR TITLE
[enhance]: de-register broker node when shutdown

### DIFF
--- a/app/broker/runtime.go
+++ b/app/broker/runtime.go
@@ -291,7 +291,9 @@ func (r *runtime) Stop() {
 	// close registry, deregister broker node from active list
 	if r.registry != nil {
 		r.logger.Info("closing discovery-registry...")
-		// TODO: add unregistry
+		if err := r.registry.Deregister(r.node); err != nil {
+			r.logger.Error("unregister broker node error", logger.Error(err))
+		}
 		if err := r.registry.Close(); err != nil {
 			r.logger.Error("unregister broker node error", logger.Error(err))
 		} else {

--- a/app/broker/runtime_test.go
+++ b/app/broker/runtime_test.go
@@ -250,6 +250,7 @@ func TestBrokerRuntime_Stop(t *testing.T) {
 	connectionMgr := rpc.NewMockConnectionManager(ctrl)
 	channelMgr := replica.NewMockChannelManager(ctrl)
 	grpcServer := rpc.NewMockGRPCServer(ctrl)
+	registry.EXPECT().Deregister(gomock.Any()).Return(fmt.Errorf("err")).AnyTimes()
 
 	cases := []struct {
 		name    string


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #892 

Problem Summary:
- de-register broker node when server shutdown

### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [x] No code
