### PR TITLE
[bug]: fix nil point when parse wrong sql

### DIFF
--- a/app/broker/api/exec/execute.go
+++ b/app/broker/api/exec/execute.go
@@ -131,6 +131,10 @@ func (e *ExecuteAPI) execute(c *gin.Context) error {
 		return err
 	}
 
+	if stmt == nil {
+		return errors.New("can't parse lin query language")
+	}
+
 	if commandFn, ok := commands[stmt.StatementType()]; ok {
 		result, err := commandFn(ctx, e.deps, &param, stmt)
 		if err != nil {

--- a/app/broker/api/exec/execute_test.go
+++ b/app/broker/api/exec/execute_test.go
@@ -95,6 +95,13 @@ func TestExecuteAPI_Execute(t *testing.T) {
 			},
 		},
 		{
+			name:    "parse sql failure",
+			reqBody: `{"sql":"abcs"}`,
+			assert: func(resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusInternalServerError, resp.Code)
+			},
+		},
+		{
 			name:    "unknown metadata statement type",
 			reqBody: `{"sql":"show master"}`,
 			prepare: func() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #924 

Problem Summary:
fix nil point error when parse wrong sql.
rc: current parse sql not throw error

### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [x] No code
