### PR TITLE
[feat]: support release with a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Build the manager binary
+FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG LD_FLAGS
+
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY embed.go embed.go
+COPY aggregation/ aggregation/
+COPY app/ app/
+COPY bin/  bin/
+COPY cmd/ cmd/
+COPY config/ config/
+COPY constants/ constants/
+COPY coordinator/ coordinator/
+COPY data/ data/
+COPY docker/ docker/
+COPY flow/ flow/
+COPY e2e/ e2e/
+COPY ingestion/ ingestion/
+COPY internal/ internal/
+COPY kv/ kv/
+COPY metrics/ metrics/
+COPY models/ models/
+COPY pkg/ pkg/
+COPY proto/ proto/
+COPY query/ query/
+COPY release/ release/
+COPY replica/ replica/
+COPY rpc/ rpc/
+COPY scripts/ scripts/
+COPY series/ series/
+COPY sql/ sql/
+COPY tsdb/ tsdb/
+COPY web/ web/
+COPY docs/ docs/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN	CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build "${LD_FLAGS}" -o lind ./cmd/lind
+
+
+FROM centos:latest
+WORKDIR /
+COPY --from=builder /workspace/lind /usr/bin/lind
+RUN mkdir /lindb
+
+USER 0:0

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ build-lind: ## build lindb binary
 deploy: build-frontend ## deploy release packages
 	sh deploy.sh
 
+.PHONY: docker-build
+docker-build: ## build docker image
+	docker build -t wangguohao/lindb:$(GIT_TAG_NAME) --build-arg LD_FLAGS=${LD_FLAGS} .
+
+.PHONY: docker-push
+docker-push: ## push docker image
+	docker push wangguohao/lindb:$(GIT_TAG_NAME)
+
 GOMOCK_VERSION = "v1.5.0"
 
 gomock: ## go generate mock file.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  not created yet

Problem Summary:

support release with a docker image.

Maybe we should create an official repo.  @stone1100 

## self-test

### build

```
$ make docker-build
docker build -t wangguohao/lindb:v0.2.1 --build-arg LD_FLAGS=-ldflags="-s -w -X github.com/lindb/lindb/config.Version=v0.2.1 -X github.com/lindb/lindb/config.BuildTime=2023-03-09T11:22:11+0800" .
[+] Building 91.8s (39/43)
[+] Building 91.9s (39/43)
[+] Building 92.4s (39/43)
[+] Building 92.8s (39/43)
[+] Building 134.4s (41/43)
[+] Building 158.1s (44/44) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                           0.1s
 => => transferring dockerfile: 37B                                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                              0.1s
 => => transferring context: 2B                                                                                                                                                                0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                                                                                              0.8s
 => [internal] load metadata for docker.io/library/golang:1.19                                                                                                                                 2.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                  0.0s
 => CACHED [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:775156d9ad597260d6e9cd0a8a400e56f2a860b845e54d8e48ce6da22f90240f                                                         0.0s
 => [internal] load build context                                                                                                                                                              2.2s
 => => transferring context: 2.89MB                                                                                                                                                            2.0s
 => [builder  1/35] FROM docker.io/library/golang:1.19@sha256:5d947843dde82ba1df5ac1b2ebb70b203d106f0423bf5183df3dc96f6bc5a705                                                                 0.0s
 => CACHED [builder  2/35] WORKDIR /workspace                                                                                                                                                  0.0s
 => CACHED [builder  3/35] COPY go.mod go.mod                                                                                                                                                  0.0s
 => CACHED [builder  4/35] COPY go.sum go.sum                                                                                                                                                  0.0s
 => [builder  5/35] RUN go mod download                                                                                                                                                       72.2s
 => [builder  6/35] COPY embed.go embed.go                                                                                                                                                     0.1s
 => [builder  7/35] COPY aggregation/ aggregation/                                                                                                                                             0.0s
 => [builder  8/35] COPY app/ app/                                                                                                                                                             0.0s
 => [builder  9/35] COPY bin/  bin/                                                                                                                                                            3.5s
 => [builder 10/35] COPY cmd/ cmd/                                                                                                                                                             0.0s
 => [builder 11/35] COPY config/ config/                                                                                                                                                       0.0s
 => [builder 12/35] COPY constants/ constants/                                                                                                                                                 0.0s
 => [builder 13/35] COPY coordinator/ coordinator/                                                                                                                                             0.0s
 => [builder 14/35] COPY data/ data/                                                                                                                                                           2.9s
 => [builder 15/35] COPY docker/ docker/                                                                                                                                                       0.5s
 => [builder 16/35] COPY flow/ flow/                                                                                                                                                           0.5s
 => [builder 17/35] COPY e2e/ e2e/                                                                                                                                                             0.4s
 => [builder 18/35] COPY ingestion/ ingestion/                                                                                                                                                 0.2s
 => [builder 19/35] COPY internal/ internal/                                                                                                                                                   0.3s
 => [builder 20/35] COPY kv/ kv/                                                                                                                                                               0.2s
 => [builder 21/35] COPY metrics/ metrics/                                                                                                                                                     0.2s
 => [builder 22/35] COPY models/ models/                                                                                                                                                       0.2s
 => [builder 23/35] COPY pkg/ pkg/                                                                                                                                                             0.3s
 => [builder 24/35] COPY proto/ proto/                                                                                                                                                         0.1s
 => [builder 25/35] COPY query/ query/                                                                                                                                                         0.2s
 => [builder 26/35] COPY release/ release/                                                                                                                                                     0.1s
 => [builder 27/35] COPY replica/ replica/                                                                                                                                                     0.2s
 => [builder 28/35] COPY rpc/ rpc/                                                                                                                                                             0.2s
 => [builder 29/35] COPY scripts/ scripts/                                                                                                                                                     0.4s
 => [builder 30/35] COPY series/ series/                                                                                                                                                       0.1s
 => [builder 31/35] COPY sql/ sql/                                                                                                                                                             0.1s
 => [builder 32/35] COPY tsdb/ tsdb/                                                                                                                                                           0.2s
 => [builder 33/35] COPY web/ web/                                                                                                                                                            12.2s
 => [builder 34/35] COPY docs/ docs/                                                                                                                                                           0.1s
 => [builder 35/35] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build "-ldflags=-s -w -X github.com/lindb/lindb/config.Version=v0.2.1 -X github.com/lindb/lindb/config.BuildTime=2023-0  55.6s
 => [stage-1 2/3] COPY --from=builder /workspace/lind .                                                                                                                                        0.2s
 => exporting to image                                                                                                                                                                         0.3s
 => => exporting layers                                                                                                                                                                        0.3s
 => => writing image sha256:da0f4a9e11626fed2c53d6c0afc755e8dadfa9daa199fec47863c107f9e08da3                                                                                                   0.0s
 => => naming to docker.io/wangguohao/lindb:v0.2.1                                                                                                                                             0.0s
```

### push

```
$ make docker-push
docker push wangguohao/lindb:v0.2.1
The push refers to repository [docker.io/wangguohao/lindb]
1112ca8d9cab: Pushed
28e757e6e258: Pushed
v0.2.1: digest: sha256:489728e3422a318809f84f993a6b1578f4d341370631e9a0fbdfc9f8bffe18aa size: 739
```
