### PR TITLE
[enhance]: consume group wait strategy when WAL is empty

### DIFF
--- a/pkg/queue/fanout_queue_test.go
+++ b/pkg/queue/fanout_queue_test.go
@@ -73,6 +73,7 @@ func TestFanOutQueue_New(t *testing.T) {
 	// case 2: create consumerGroup path err
 	queue := NewMockQueue(ctrl)
 	queue.EXPECT().Close().AnyTimes()
+	queue.EXPECT().Signal().AnyTimes()
 
 	newQueueFunc = func(dirPath string, dataSizeLimit int64) (Queue, error) {
 		return queue, nil

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -69,6 +69,10 @@ type Queue interface {
 	AcknowledgedSeq() int64
 	// SetAcknowledgedSeq sets acknowledged sequence.
 	SetAcknowledgedSeq(seq int64)
+	// NotEmpty checks queue if empty, waiting until new data written.
+	NotEmpty(consumeHead int64, checkClosed func() bool) bool
+	// Signal signals waiting consumers.
+	Signal()
 	// GC removes all message which sequence <= acknowledged sequence.
 	GC()
 	// Close closes the queue.
@@ -98,7 +102,9 @@ type queue struct {
 	messageOffset int
 
 	closed  atomic.Bool
-	rwMutex sync.RWMutex
+	rwMutex *sync.RWMutex
+
+	notEmpty *sync.Cond // not empty condition
 }
 
 // NewQueue returns Queue based on dirPath, dataSizeLimit is used to limit the total data/index size,
@@ -106,9 +112,12 @@ func NewQueue(dirPath string, dataSizeLimit int64) (Queue, error) {
 	if err := mkDirFunc(dirPath); err != nil {
 		return nil, err
 	}
+	lock := &sync.RWMutex{}
 	q := &queue{
 		dirPath:       dirPath,
 		dataSizeLimit: dataSizeLimit,
+		rwMutex:       lock,
+		notEmpty:      sync.NewCond(lock),
 	}
 
 	// if data size limit < default limit, need reset
@@ -282,11 +291,29 @@ func (q *queue) SetAcknowledgedSeq(seq int64) {
 	}
 }
 
+// NotEmpty checks queue if empty, waiting until new data written.
+func (q *queue) NotEmpty(consumeHead int64, checkClosed func() bool) bool {
+	q.notEmpty.L.Lock()
+	for consumeHead > q.appendedSeq.Load() && !q.closed.Load() && !checkClosed() {
+		q.notEmpty.Wait()
+	}
+	q.notEmpty.L.Unlock()
+
+	return !q.closed.Load() && !checkClosed()
+}
+
+// Signal signals waiting consumers.
+func (q *queue) Signal() {
+	q.notEmpty.Broadcast()
+}
+
 // Close closes the queue.
 func (q *queue) Close() {
 	if q.closed.CAS(false, true) {
 		q.rwMutex.RLock()
 		defer q.rwMutex.RUnlock()
+
+		q.notEmpty.Broadcast()
 
 		if q.dataPageFct != nil {
 			if err := q.dataPageFct.Close(); err != nil {
@@ -399,6 +426,9 @@ func (q *queue) persistMetaOfMessage(dataPageIndex int64, dataLen, messageOffset
 	// save metadata
 	q.metaPage.PutUint64(uint64(seq), queueAppendedSeqOffset)
 	q.appendedSeq.Store(seq)
+
+	// new data written, notify all waiting consumer groups can consume data
+	q.notEmpty.Broadcast()
 	return nil
 }
 

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -303,7 +303,9 @@ func TestQueue_Close(t *testing.T) {
 		dataPageFct:  pageFct,
 		indexPageFct: pageFct,
 		metaPageFct:  pageFct,
+		rwMutex:      &sync.RWMutex{},
 	}
+	q.notEmpty = sync.NewCond(q.rwMutex)
 	q.Close()
 }
 

--- a/replica/partition_test.go
+++ b/replica/partition_test.go
@@ -395,6 +395,8 @@ func TestPartition_Stop(t *testing.T) {
 	peer1 := NewMockReplicatorPeer(ctrl)
 	peer2 := NewMockReplicatorPeer(ctrl)
 	ctx, cancel := context.WithCancel(context.TODO())
+	log := queue.NewMockFanOutQueue(ctrl)
+	log.EXPECT().StopConsumerGroup(gomock.Any()).AnyTimes()
 	p := &partition{
 		ctx:    ctx,
 		cancel: cancel,
@@ -402,6 +404,7 @@ func TestPartition_Stop(t *testing.T) {
 			1: peer1,
 			2: peer2,
 		},
+		log: log,
 	}
 	peer1.EXPECT().Shutdown()
 	peer2.EXPECT().Shutdown()

--- a/replica/replicator.go
+++ b/replica/replicator.go
@@ -39,6 +39,8 @@ type Replicator interface {
 	ReplicaState() *models.ReplicaState
 	// State returns the state of replicator.
 	State() *state
+	// Pause paused replica data.
+	Pause()
 	// Consume returns the index of message replica.
 	Consume() int64
 	// GetMessage returns message by replica index.
@@ -87,6 +89,11 @@ func (r *replicator) Replica(_ int64, _ []byte) {
 // IsReady returns if replicator is ready.
 func (r *replicator) IsReady() bool {
 	return true
+}
+
+// Pause paused replica data.
+func (r *replicator) Pause() {
+	r.channel.ConsumerGroup.Pause()
 }
 
 // Connect connects follower for sending replica message.

--- a/replica/replicator_test.go
+++ b/replica/replicator_test.go
@@ -93,5 +93,8 @@ func TestReplicator_Base(t *testing.T) {
 	cg.EXPECT().Pending().Return(int64(10))
 	assert.Equal(t, int64(10), r.Pending())
 
+	cg.EXPECT().Pause()
+	r.Pause()
+
 	r.Close()
 }


### PR DESCRIPTION
### What problem does this PR solve?
- remove sleep logic when cannot consume wal data
- wait strategy based on sync.Condition

Issue Number: #959 

Problem Summary:

### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [x] No code
