### PR TITLE
[bug]: fix nil metadata and refactor lindcli

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -240,7 +240,7 @@ func main() {
 		prompt.OptionTitle("LinDB Client"),
 
 		prompt.OptionPrefixTextColor(prompt.DarkGreen),
-		prompt.OptionInputTextColor(prompt.DarkBlue),
+		prompt.OptionInputTextColor(prompt.White),
 
 		prompt.OptionSuggestionBGColor(prompt.LightGray),
 		prompt.OptionSuggestionTextColor(prompt.Black),

--- a/internal/client/execute.go
+++ b/internal/client/execute.go
@@ -81,12 +81,18 @@ func (cli *executeCli) Execute(param models.ExecuteParam, rs interface{}) error 
 }
 
 // ExecuteAsResult executes lin query language, then returns terminal result.
-func (cli *executeCli) ExecuteAsResult(param models.ExecuteParam, rs interface{}) (string, error) {
+func (cli *executeCli) ExecuteAsResult(param models.ExecuteParam, rs interface{}) (queryResult string, err error) {
+	defer func() {
+		if err0 := recover(); err0 != nil {
+			err = fmt.Errorf("query error: %v", err0)
+		}
+	}()
+
 	n := time.Now()
-	err := cli.Execute(param, rs)
+	err = cli.Execute(param, rs)
 	cost := time.Since(n)
 	if err != nil {
-		return "", err
+		return
 	}
 	result := ""
 	rows := 0

--- a/query/search.go
+++ b/query/search.go
@@ -181,7 +181,7 @@ func buildMetadataResultSet(statement *stmtpkg.MetricMetadata, result []string) 
 		// underlying histogram data is only restricted access by user via quantile function
 		// furthermore, we suggest some quantile functions for user in field names, such as quantile(0.99)
 		var (
-			resultFields []commonmodels.Field
+			resultFields = make([]commonmodels.Field, 0)
 			hasHistogram bool
 		)
 		for _, f := range result {
@@ -210,6 +210,9 @@ func buildMetadataResultSet(statement *stmtpkg.MetricMetadata, result []string) 
 			Values: resultFields,
 		}, nil
 	default:
+		if values == nil {
+			values = make([]string, 0)
+		}
 		return &commonmodels.Metadata{
 			Type:   statement.Type.String(),
 			Values: values,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #991 

Problem Summary:

1. Always return empty value instead of nil when querying metadata.
2. Modify the color of the input sql and add the recover function.

### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [x] No code
