### PR TITLE
[bug]: fix storage panic when write old data point

### DIFF
--- a/app/broker/api/exec/command/schema.go
+++ b/app/broker/api/exec/command/schema.go
@@ -127,6 +127,8 @@ func saveDataBase(ctx context.Context, deps *depspkg.HTTPDeps, stmt *stmtpkg.Sch
 	}
 
 	log.Info("Saving Database", logger.String("config", stmt.Value))
+	// reset database after check and set default value
+	data = encoding.JSONMarshal(database)
 	if err := deps.Repo.Put(ctx, constants.GetDatabaseConfigPath(database.Name), data); err != nil {
 		return nil, err
 	}

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -68,6 +68,9 @@ var (
 	// ErrEmptySelectList represents empty select list.
 	ErrEmptySelectList = errors.New("select item list is empty")
 
+	// ErrPartitionClosed represents paritition is already closed.
+	ErrPartitionClosed = errors.New("partition is closed")
+
 	ErrDatabaseNotExist       = errors.New("database not exist")
 	ErrNoAvailableStorageNode = errors.New("no available storage node for server")
 

--- a/replica/replicator_remote.go
+++ b/replica/replicator_remote.go
@@ -215,8 +215,10 @@ func (r *remoteReplicator) IsReady() bool {
 			r.logger.Warn("do reset replica append index err",
 				logger.String("replicator", r.String()),
 				logger.Error(err))
-			r.state.Store(&state{state: models.ReplicatorFailureState,
-				errMsg: "reset replica append index failure, root cause: " + err.Error()})
+			r.state.Store(&state{
+				state:  models.ReplicatorFailureState,
+				errMsg: "reset replica append index failure, root cause: " + err.Error(),
+			})
 			return false
 		}
 		r.statistics.ResetFollowerAppendIdx.Incr()
@@ -284,6 +286,7 @@ func (r *remoteReplicator) Replica(idx int64, msg []byte) {
 		logger.String("replicator", r.String()),
 		logger.Int64("replicaIdx", resp.ReplicaIndex),
 		logger.Int64("ackIdx", resp.AckIndex))
+	// FIXME: need check resp err
 	if resp.AckIndex == resp.ReplicaIndex {
 		// if ack index = replica, need ack wal
 		r.SetAckIndex(resp.AckIndex)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1017

Problem Summary:
storage will panic when write old data point.

Rootcause:
- broker not filter old data point, because database not set default write acceptable time range.
- storage close wal log

### Check List

Tests 

- [ ] Unit test
- [ ] Integration test
- [ ] No code
